### PR TITLE
Include opendata.swiss data when searching wms layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Type the text to search in the locator bar.
 If the result is a **WMS layer**, double-clicking on it will try to add it to the map. 
 It might not be possible since some layers are only visible in the geoportal.
 In any case, a link will be shown to display the layer in the geoportal.
-In the case a opendata.swiss service contains more layers, a datasource to the WMS will be established.
+If an opendata.swiss service contains more layers, a datasource to the WMS will be established.
 
 If the result is a **location** or **feature**, 
 double-clicking on it will move the map canvas to the result and highlight its position.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Similarly to the online geoportal [https://map.geo.admin.ch](https://map.geo.adm
    * ZIP codes
    * addresses
    * cadastral parcels
-* WMS layers, which can easily be added to the map
+* WMS layers from Federal Geoportal (map.geo.admin.ch) or opendata.swiss, which can easily be added to the map
 * features (search through features descriptions)
 
 
@@ -39,6 +39,7 @@ Type the text to search in the locator bar.
 If the result is a **WMS layer**, double-clicking on it will try to add it to the map. 
 It might not be possible since some layers are only visible in the geoportal.
 In any case, a link will be shown to display the layer in the geoportal.
+In the case a opendata.swiss service contains more layers, a datasource to the WMS will be established.
 
 If the result is a **location** or **feature**, 
 double-clicking on it will move the map canvas to the result and highlight its position.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Configuration is achieved in the main application settings under the `locator` t
 * enable or disable searches (locations, layers, features)
 * customize prefixes, define if they are default filters (used without prefix)
 * access to the configuration of the plugin
+* include or exclude opendata.swiss data from layer searches
 
 In the configuration of the plugin, further customization can be achieved:
 * language definition (English, German, French, Italian, Rumantsch)

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ In the configuration of the plugin, further customization can be achieved:
 Type the text to search in the locator bar.
 
 If the result is a **WMS layer**, double-clicking on it will try to add it to the map. 
-It might not be possible since some layers are only visible in the geoportal.
-In any case, a link will be shown to display the layer in the geoportal.
-If an opendata.swiss service contains more layers, a datasource to the WMS will be established.
+It might not be possible since some layers are only visible in the geoportal (map.geo.admin.ch).
+In this case, a link will be shown to display the layer in the geoportal.
 
 If the result is a **location** or **feature**, 
 double-clicking on it will move the map canvas to the result and highlight its position.

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -52,5 +52,5 @@ class Settings(SettingManager):
         self.add_setting(Bool("feature_search_restrict", Scope.Global, False))
         self.add_setting(Stringlist("feature_search_layers_list", Scope.Global, None))
 
-
+        self.add_setting(Bool("layers_include_opendataswiss", Scope.Global, True))
 

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -18,7 +18,7 @@ repository=https://github.com/opengisch/qgis-swiss-locator
 category=Web
 
 # experimental flag
-experimental=True
+experimental=False
 
 # change icon...
 icon=icons/swiss_locator.png

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -2,14 +2,14 @@
 [general]
 name=Swiss Locator
 qgisMinimumVersion=3.2
-description=A locator filter for Swiss Geoportal (geo.admin.ch)
-about=Search for locations, WMS layers of features in the whole Swiss Geoportal catalog
+description=A locator filter for Swiss Geoportal (geo.admin.ch) and opendata.swiss resources
+about=Search for locations, WMS layers of features in the whole Swiss Geoportal catalog as well as in opendata.swiss
 version=dev
 author=Denis Rouzaud
 email=denis@opengis.ch
 
 # Tags are comma separated with spaces allowed
-tags=swiss, suisse, schweiz, locator, geoadmin, geoportal
+tags=swiss, suisse, schweiz, locator, geoadmin, geoportal, opendata.swiss
 
 tracker=https://github.com/opengisch/qgis-swiss-locator
 homepage=https://github.com/opengisch/qgis-swiss-locator
@@ -18,7 +18,7 @@ repository=https://github.com/opengisch/qgis-swiss-locator
 category=Web
 
 # experimental flag
-experimental=False
+experimental=True
 
 # change icon...
 icon=icons/swiss_locator.png

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -621,8 +621,8 @@ class SwissLocatorFilter(QgsLocatorFilter):
 
             if 'geo.admin.ch' in swiss_result.url.lower():
                 label.setText('<a href="https://map.geo.admin.ch/'
-                                '?lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers={}">'
-                                'Open layer in map.geo.admin.ch</a>'.format(swiss_result.layer))
+                                '?lang={}&bgLayer=ch.swisstopo.pixelkarte-farbe&layers={}">'
+                                'Open layer in map.geo.admin.ch</a>'.format(self.lang, swiss_result.layer))
 
             if not wms_layer.isValid():
                 msg = self.tr('Cannot load WMS layer: {} ({})'.format(swiss_result.title, swiss_result.layer))

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -487,6 +487,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
                             if res['media_type'] == 'WMS':
                                 result = QgsLocatorResult()
                                 result.filter = self
+                                result.group = 'opendata.swiss WMS layers'
                                 result.displayString = display_name
                                 result.description = url
 
@@ -502,22 +503,25 @@ class SwissLocatorFilter(QgsLocatorFilter):
                             elif 'request=getcapabilities' in url.lower():
                                 result = QgsLocatorResult()
                                 result.filter = self
+                                result.group = 'opendata.swiss WMS datasources'
                                 result.displayString = display_name
                                 result.description = url
                                 result.userData = WMSCapabilitiesResult(title=display_name, url=url).as_definition()
-                                result.icon = QgsApplication.getThemeIcon("/mActionAdd.svg")
+                                result.icon = QgsApplication.getThemeIcon("/mActionAddWmsLayer.svg")
                                 self.result_found = True
                                 self.resultFetched.emit(result)
 
             else:
                 for loc in data['results']:
                     self.dbg_info("keys: {}".format(loc['attrs'].keys()))
+
+                    result = QgsLocatorResult()
+                    result.filter = self
+                    result.group = 'Swiss Geoportal WMS layers'
                     if loc['attrs']['origin'] == 'layer':
                         # available keys: ﻿['origin', 'lang', 'layer', 'staging', 'title', 'topics', 'detail', 'label', 'id']
                         for key, val in loc['attrs'].items():
                             self.dbg_info('{}: {}'.format(key, val))
-                        result = QgsLocatorResult()
-                        result.filter = self
                         result.displayString = loc['attrs']['title']
                         result.description = loc['attrs']['layer']
                         result.userData = WMSLayerResult(layer=loc['attrs']['layer'], title=loc['attrs']['title'], url='http://wms.geo.admin.ch/?VERSION%3D2.0.0').as_definition()
@@ -528,8 +532,6 @@ class SwissLocatorFilter(QgsLocatorFilter):
                     elif loc['attrs']['origin'] == 'feature':
                         for key, val in loc['attrs'].items():
                             self.dbg_info('{}: {}'.format(key, val))
-                        result = QgsLocatorResult()
-                        result.filter = self
                         layer = loc['attrs']['layer']
                         point = QgsPointXY(loc['attrs']['lon'], loc['attrs']['lat'])
                         if layer in self.searchable_layers:
@@ -556,8 +558,6 @@ class SwissLocatorFilter(QgsLocatorFilter):
                         if 'featureId' in loc['attrs']:
                             self.dbg_info("feature: {}".format(loc['attrs']['featureId']))
 
-                        result = QgsLocatorResult()
-                        result.filter = self
                         result.displayString = strip_tags(loc['attrs']['label'])
                         # result.description = loc['attrs']['detail']
                         # if 'featureId' in loc['attrs']:

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -31,7 +31,7 @@ from PyQt5.QtCore import QUrl, QUrlQuery, pyqtSignal, QEventLoop
 
 from qgis.core import Qgis, QgsLocatorFilter, QgsLocatorResult, QgsRectangle, QgsApplication, \
     QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsGeometry, QgsWkbTypes, QgsPointXY, \
-    QgsLocatorContext, QgsFeedback, QgsRasterLayer, QgsSettings, QgsMessageLog
+    QgsLocatorContext, QgsFeedback, QgsRasterLayer
 from qgis.gui import QgsRubberBand, QgisInterface
 
 from swiss_locator.core.network_access_manager import NetworkAccessManager, RequestsException, RequestsExceptionUserAbort

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -618,19 +618,19 @@ class SwissLocatorFilter(QgsLocatorFilter):
             label.setTextFormat(Qt.RichText)
             label.setTextInteractionFlags(Qt.TextBrowserInteraction)
             label.setOpenExternalLinks(True)
+
+            if 'geo.admin.ch' in swiss_result.url.lower():
+                label.setText('<a href="https://map.geo.admin.ch/'
+                                '?lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers={}">'
+                                'Open layer in map.geo.admin.ch</a>'.format(swiss_result.layer))
+
             if not wms_layer.isValid():
                 msg = self.tr('Cannot load WMS layer: {} ({})'.format(swiss_result.title, swiss_result.layer))
                 level = Qgis.Warning
-                label.setText('<a href="https://map.geo.admin.ch/'
-                              '?lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers={}">'
-                              'Open layer in map.geo.admin.ch</a>'.format(swiss_result.layer))
                 self.info(msg, level)
             else:
                 msg = self.tr('WMS layer added to the map: {} ({})'.format(swiss_result.title, swiss_result.layer))
                 level = Qgis.Info
-                label.setText('<a href="https://map.geo.admin.ch/'
-                              '?lang=fr&bgLayer=ch.swisstopo.pixelkarte-farbe&layers={}">'
-                              'Open layer in map.geo.admin.ch</a>'.format(swiss_result.layer))
 
                 QgsProject.instance().addMapLayer(wms_layer)
 

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -384,9 +384,11 @@ class SwissLocatorFilter(QgsLocatorFilter):
                 feedback.canceled.connect(nam.abort)
 
                 searchUrls = [
-                    (url, params),
-                    ('https://opendata.swiss/api/3/action/package_search?', {'q': 'q=WMS+%C3'+str(search)})
+                    (url, params)
                 ]
+
+                if self.settings.value('layers_include_opendataswiss') and self.type is FilterType.WMS:
+                    searchUrls.append(('https://opendata.swiss/api/3/action/package_search?', {'q': 'q=WMS+%C3'+str(search)}))
 
                 for (url, params) in searchUrls:
                     url = self.url_with_param(url, params)

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -765,11 +765,11 @@ class SwissLocatorFilter(QgsLocatorFilter):
         from PyQt5.QtCore import QSettings
         from qgis.core import QgsDataSourceUri
 
+        datasource_uri = QgsDataSourceUri()
         settings = QSettings()
 
         settings.beginGroup(u"/Qgis/connections-wms/")
         settings.beginGroup(name)
-        datasource_uri = QgsDataSourceUri()
         settings.setValue("url", url)
         settings.setValue("ignoreGetMapURI", datasource_uri.param('IgnoreGetMapUrl') == "1")
         settings.setValue("ignoreAxisOrientation", datasource_uri.param('IgnoreAxisOrientation') == "1")
@@ -784,6 +784,8 @@ class SwissLocatorFilter(QgsLocatorFilter):
         settings.beginGroup(name)
         settings.setValue("username", datasource_uri.param('username'))
         settings.setValue("password", datasource_uri.param('password'))
+        settings.endGroup()
+        settings.endGroup()
 
     def is_opendata_swiss_response(self, json):
         return 'opendata.swiss' in json.get("help", [])

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -475,15 +475,16 @@ class SwissLocatorFilter(QgsLocatorFilter):
 
             if self.is_opendata_swiss_response(data):
                 for loc in data['result']['results']:
-                    display_name = loc['display_name'].get(self.lang, "")
+                    display_name = loc['title'].get(self.lang, "")
                     if not display_name:
                         # Fallback to german
-                        display_name = loc['display_name']['de']
+                        display_name = loc['title']['de']
 
                     for res in loc['resources']:
+
                         url = res['url']
                         if 'wms' in url.lower():
-                            if res['format'] == 'WMS':
+                            if res['media_type'] == 'WMS':
                                 result = QgsLocatorResult()
                                 result.filter = self
                                 result.displayString = display_name
@@ -498,7 +499,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
                                     self.resultFetched.emit(result)
                                 #todo: add else if no GetMap-URL is found
 
-                            elif res['format'] == 'SERVICE':
+                            elif 'request=getcapabilities' in url.lower():
                                 result = QgsLocatorResult()
                                 result.filter = self
                                 result.displayString = display_name

--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -475,19 +475,24 @@ class SwissLocatorFilter(QgsLocatorFilter):
 
             if self.is_opendata_swiss_response(data):
                 for loc in data['result']['results']:
+                    display_name = loc['display_name'].get(self.lang, "")
+                    if not display_name:
+                        # Fallback to german
+                        display_name = loc['display_name']['de']
+
                     for res in loc['resources']:
                         url = res['url']
                         if 'wms' in url.lower():
                             if res['format'] == 'WMS':
                                 result = QgsLocatorResult()
                                 result.filter = self
-                                result.displayString = loc['display_name']['de']  #todo: support translation
+                                result.displayString = display_name
                                 result.description = url
 
                                 if res['title']['de'] == 'GetMap':
                                     u = urlparse(url)
                                     layers = parse_qs(u.query)['LAYERS']
-                                    result.userData = WMSLayerResult(layer=layers[0], title=loc['display_name']['de'], url=u.scheme + '://' + u.netloc + '/' + u.path + '?').as_definition()
+                                    result.userData = WMSLayerResult(layer=layers[0], title=display_name, url=u.scheme + '://' + u.netloc + '/' + u.path + '?').as_definition()
                                     result.icon = QgsApplication.getThemeIcon("/mActionAddWmsLayer.svg")
                                     self.result_found = True
                                     self.resultFetched.emit(result)
@@ -496,9 +501,9 @@ class SwissLocatorFilter(QgsLocatorFilter):
                             elif res['format'] == 'SERVICE':
                                 result = QgsLocatorResult()
                                 result.filter = self
-                                result.displayString = loc['display_name']['de']  #todo: support translation
+                                result.displayString = display_name
                                 result.description = url
-                                result.userData = WMSCapabilitiesResult(title=loc['display_name']['de'], url=url).as_definition()
+                                result.userData = WMSCapabilitiesResult(title=display_name, url=url).as_definition()
                                 result.icon = QgsApplication.getThemeIcon("/mActionAdd.svg")
                                 self.result_found = True
                                 self.resultFetched.emit(result)

--- a/swiss_locator/ui/config.ui
+++ b/swiss_locator/ui/config.ui
@@ -234,7 +234,10 @@
        <item row="1" column="1">
         <widget class="QSpinBox" name="layers_limit"/>
        </item>
-       <item row="2" column="0">
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="layers_include_opendataswiss"/>
+       </item>
+       <item row="3" column="0">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -246,6 +249,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Include data from opendata.swiss</string>
+         </property>
+        </widget>
        </item>
        <item row="1" column="0">
         <widget class="QLabel" name="label_7">


### PR DESCRIPTION
**Add support for [opendata.swiss](https://opendata.swiss) WMS layers in swiss locator search (with keyword `chw`):**
* Search for opendata.swiss data can be toggled in the locator configuration
* Search results are grouped by datasource (currently either `Swiss Geoportal` or `opendata.swiss`)
* If opendata.swiss responses contain links to WMS capabilities instead of WMS layers, the capabilities get requested and parsed for matching WMS layers

