### PR TITLE
Add missing `feedback` parameter

### DIFF
--- a/swiss_locator/swiss_locator_filter.py
+++ b/swiss_locator/swiss_locator_filter.py
@@ -401,7 +401,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
                 self.event_loop = QEventLoop()
 
                 def reply_finished(response):
-                    self.handle_response(response, search)
+                    self.handle_response(response, search, feedback)
                     if response.url in self.access_managers:
                         self.access_managers[response.url] = None
                     for nam in self.access_managers.values():


### PR DESCRIPTION
Fixes a python error, unsure about consequences

```
WARNING    Traceback (most recent call last):
              File "profiles/default/python/plugins/swiss_locator/swiss_locator_filter.py", line 404, in reply_finished
              self.handle_response(response, search, feedback)
             TypeError: handle_response() missing 1 required positional argument: 'feedback'
```