### PR TITLE
Fix exception when loading layer with custom CRS

### DIFF
--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -189,7 +189,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
         self.crs = self.settings.value("crs")
         if self.crs == "project":
             map_crs = self.map_canvas.mapSettings().destinationCrs()
-            if map_crs.isValid():
+            if map_crs.isValid() and ":" in map_crs.authid():
                 self.crs = map_crs.authid().split(":")[1]
             if self.crs not in AVAILABLE_CRS:
                 self.crs = "2056"


### PR DESCRIPTION
A CRS may be valid without having an authid
```
IndexError: list index out of range 
Traceback (most recent call last):
  File "python/plugins/swiss_locator/core/filters/swiss_locator_filter.py", line 193, in create_transforms
    self.crs = map_crs.authid().split(":")[1]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```