### PR TITLE
Generating profiles using profile rest API

### DIFF
--- a/swiss_locator/core/profiles/profile_generator.py
+++ b/swiss_locator/core/profiles/profile_generator.py
@@ -1,0 +1,115 @@
+import json
+
+from qgis.PyQt.QtCore import QEventLoop, QUrl, QUrlQuery
+from qgis.PyQt.QtNetwork import QNetworkRequest
+from qgis.core import (
+    QgsAbstractProfileGenerator,
+    QgsAbstractProfileSource,
+    QgsFeedback,
+    QgsGeometry,
+    QgsNetworkAccessManager,
+    QgsPoint,
+)
+
+from swiss_locator.core.profiles.profile_results import  SwissProfileResults
+
+NB_POINTS = '100'  # The number of points used for the polyline segmentation. Default “200”.
+
+
+class SwissProfileGenerator(QgsAbstractProfileGenerator):
+    X = "easting"
+    Y = "northing"
+    DISTANCE = "dist"
+    Z_DICT = "alts"
+    Z = "DTM2"
+
+    def __init__(self, request):
+        QgsAbstractProfileGenerator.__init__(self)
+        self.__request = request
+        self.__profile_curve = request.profileCurve().clone() if request.profileCurve() else None
+        self.__results = None  # SwissProfileResults()
+        self.__feedback = QgsFeedback()
+
+    def sourceId(self):
+        return "swiss-profile"
+
+    def __get_profile_from_rest_api(self):
+        def url_with_param(url, params) -> str:
+            url = QUrl(url)
+            q = QUrlQuery(url)
+            for key, value in params.items():
+                q.addQueryItem(key, value)
+            url.setQuery(q)
+            return url
+
+        result = {}
+        url = "https://api3.geo.admin.ch/rest/services/profile.json"
+
+        geojson = self.__profile_curve.asJson(3)
+        params = {"geom": geojson, "sr": '2056', "nb_points": NB_POINTS}
+        url = url_with_param(url, params)
+
+        network_access_manager = QgsNetworkAccessManager.instance()
+
+        req = QNetworkRequest(QUrl(url))
+        reply = network_access_manager.get(req)
+
+        loop = QEventLoop()
+        reply.finished.connect(loop.quit)
+        loop.exec_()
+
+        if reply.error():
+            print(reply.errorString())
+            result = {"error": reply.errorString()}
+        else:
+            content = reply.readAll()
+            result = json.loads(str(content, 'utf-8'))
+
+        reply.deleteLater()
+
+        return result
+
+    def __parse_response_point(self, point):
+        return point[self.X], point[self.Y], point[self.Z_DICT][self.Z], point[self.DISTANCE]
+
+    def generateProfile(self, context):  # QgsProfileGenerationContext
+        if self.__profile_curve is None:
+            return False
+
+        self.__results = SwissProfileResults()
+        self.__results.copyPropertiesFromGenerator(self)
+
+        result = self.__get_profile_from_rest_api()
+
+        if "error" in result:
+            print(result["error"])
+            return False
+
+        for point in result:
+            if self.__feedback.isCanceled():
+                return False
+
+            x, y, z, d = self.__parse_response_point(point)
+            self.__results.raw_points.append(QgsPoint(x, y))
+            self.__results.distance_to_height[d] = z
+            if z < self.__results.min_z:
+                self.__results.min_z = z
+
+            if z > self.__results.max_z:
+                self.__results.max_z = z
+
+            self.__results.geometries.append(QgsGeometry(QgsPoint(x, y, z)))
+            self.__results.cross_section_geometries = QgsGeometry(QgsPoint(d, z))
+
+        return not self.__feedback.isCanceled()
+
+    def takeResults(self):
+        return self.__results
+
+
+class SwissProfileSource(QgsAbstractProfileSource):
+    def __init__(self):
+        QgsAbstractProfileSource.__init__(self)
+
+    def createProfileGenerator(self, request):
+        return SwissProfileGenerator(request)

--- a/swiss_locator/core/profiles/profile_generator.py
+++ b/swiss_locator/core/profiles/profile_generator.py
@@ -71,6 +71,9 @@ class SwissProfileGenerator(QgsAbstractProfileGenerator):
     def __parse_response_point(self, point):
         return point[self.X], point[self.Y], point[self.Z_DICT][self.Z], point[self.DISTANCE]
 
+    def feedback(self):
+        return self.__feedback
+
     def generateProfile(self, context):  # QgsProfileGenerationContext
         if self.__profile_curve is None:
             return False
@@ -110,7 +113,7 @@ class SwissProfileGenerator(QgsAbstractProfileGenerator):
                 self.__results.max_z = z
 
             self.__results.geometries.append(QgsGeometry(point_z))
-            self.__results.cross_section_geometries = QgsGeometry(QgsPoint(d, z))
+            self.__results.cross_section_geometries.append(QgsGeometry(QgsPoint(d, z)))
 
         return not self.__feedback.isCanceled()
 

--- a/swiss_locator/core/profiles/profile_generator.py
+++ b/swiss_locator/core/profiles/profile_generator.py
@@ -64,7 +64,14 @@ class SwissProfileGenerator(QgsAbstractProfileGenerator):
             result = {"error": reply.errorString()}
         else:
             content = reply.content()
-            result = json.loads(str(content, 'utf-8'))
+            try:
+                result = json.loads(str(content, 'utf-8'))
+            except json.decoder.JSONDecodeError as e:
+                QgsMessageLog.logMessage(
+                    "Unable to parse results from Profile service. Details: {}".format(e.msg),
+                    "Swiss locator",
+                    Qgis.Critical
+                )
 
         return result
 

--- a/swiss_locator/core/profiles/profile_results.py
+++ b/swiss_locator/core/profiles/profile_results.py
@@ -34,12 +34,14 @@ class SwissProfileResults(QgsAbstractProfileResults):
             for geom in self.geometries:
                 feature = QgsAbstractProfileResults.Feature()
                 feature.geometry = geom
+                feature.layerIdentifier = self.type()
                 result.append(feature)
 
         elif type == Qgis.ProfileExportType.Profile2D:
             for geom in self.cross_section_geometries:
                 feature = QgsAbstractProfileResults.Feature()
                 feature.geometry = geom
+                feature.layerIdentifier = self.type()
                 result.append(feature)
 
         return result
@@ -54,7 +56,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
         return QgsDoubleRange(self.min_z, self.max_z)
 
     def type(self):
-        return "swiss-web-service"
+        return "swiss-profile-web-service"
 
     def renderResults(self, context: QgsProfileRenderContext):
         painter = context.renderContext().painter()

--- a/swiss_locator/core/profiles/profile_results.py
+++ b/swiss_locator/core/profiles/profile_results.py
@@ -1,0 +1,82 @@
+from qgis.PyQt.QtCore import QRectF, Qt, QPointF
+from qgis.PyQt.QtGui import QPainterPath, QPolygonF
+from qgis.core import (
+    Qgis,
+    QgsAbstractProfileResults,
+    QgsDoubleRange,
+    QgsMarkerSymbol,
+    QgsProfileRenderContext,
+)
+
+
+class SwissProfileResults(QgsAbstractProfileResults):
+    def __init__(self):
+        QgsAbstractProfileResults.__init__(self)
+
+        self.__profile_curve = None
+        self.raw_points = []  # QgsPointSequence
+        self.__symbology = None
+
+        self.distance_to_height = {}
+        self.geometries = []
+        self.cross_section_geometries = []
+        self.min_z = 4500
+        self.max_z = -100
+
+        self.marker_symbol = QgsMarkerSymbol.createSimple(
+            {'name': 'square', 'size': 2, 'color': '#00ff00',
+             'outline_style': 'no'})
+
+    def asFeatures(self, profile_export_type, feedback):
+        result = []
+
+        if type == Qgis.ProfileExportType.Features3D:
+            for geom in self.geometries:
+                feature = QgsAbstractProfileResults.Feature()
+                feature.geometry = geom
+                result.append(feature)
+
+        elif type == Qgis.ProfileExportType.Profile2D:
+            for geom in self.cross_section_geometries:
+                feature = QgsAbstractProfileResults.Feature()
+                feature.geometry = geom
+                result.append(feature)
+
+        return result
+
+    def asGeometries(self):
+        return self.geometries
+
+    def zRange(self):
+        return QgsDoubleRange(self.min_z, self.max_z)
+
+    def type(self):
+        return "swiss-web-service"
+
+    def renderResults(self, context: QgsProfileRenderContext):
+        painter = context.renderContext().painter()
+        if not painter:
+            return
+
+        painter.setBrush(Qt.NoBrush)
+        painter.setPen(Qt.NoPen)
+
+        minDistance = context.distanceRange().lower()
+        maxDistance = context.distanceRange().upper()
+        minZ = context.elevationRange().lower()
+        maxZ = context.elevationRange().upper()
+
+        visibleRegion = QRectF(minDistance, minZ, maxDistance - minDistance, maxZ - minZ)
+        clipPath = QPainterPath()
+        clipPath.addPolygon(context.worldTransform().map(QPolygonF(visibleRegion)))
+        painter.setClipPath(clipPath, Qt.ClipOperation.IntersectClip)
+
+        self.marker_symbol.startRender(context.renderContext())
+
+        for k, v in self.distance_to_height.items():
+            if not v:
+                continue
+
+            self.marker_symbol.renderPoint(context.worldTransform().map(QPointF(k, v)), None, context.renderContext())
+
+        self.marker_symbol.stopRender(context.renderContext())

--- a/swiss_locator/core/profiles/profile_results.py
+++ b/swiss_locator/core/profiles/profile_results.py
@@ -27,7 +27,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
             {'name': 'square', 'size': 2, 'color': '#00ff00',
              'outline_style': 'no'})
 
-    def asFeatures(self, profile_export_type, feedback):
+    def asFeatures(self, type, feedback):
         result = []
 
         if type == Qgis.ProfileExportType.Features3D:
@@ -46,6 +46,9 @@ class SwissProfileResults(QgsAbstractProfileResults):
 
     def asGeometries(self):
         return self.geometries
+
+    def sampledPoints(self):
+        return self.raw_points
 
     def zRange(self):
         return QgsDoubleRange(self.min_z, self.max_z)

--- a/swiss_locator/core/profiles/profile_results.py
+++ b/swiss_locator/core/profiles/profile_results.py
@@ -44,6 +44,19 @@ class SwissProfileResults(QgsAbstractProfileResults):
                 feature.layerIdentifier = self.type()
                 result.append(feature)
 
+        elif type == Qgis.ProfileExportType.DistanceVsElevationTable:
+            for i, geom in enumerate(self.geometries):
+                feature = QgsAbstractProfileResults.Feature()
+                feature.geometry = geom
+                feature.layerIdentifier = self.type()
+
+                # Since we've got distance/elevation pairs as
+                # x,y for cross-section geometries, and since
+                # both point arrays have the same length:
+                p = self.cross_section_geometries[i].asPoint()
+                feature.attributes = {"distance": p.x(), "elevation": p.y()}
+                result.append(feature)
+
         return result
 
     def asGeometries(self):

--- a/swiss_locator/core/profiles/profile_url.py
+++ b/swiss_locator/core/profiles/profile_url.py
@@ -1,0 +1,9 @@
+def profile_url(geojson: str):
+    base_url = "https://api3.geo.admin.ch/rest/services/profile.json"
+    base_params = {
+        "geom": geojson,
+        "sr": "2056",
+        "nb_points": "200",  # Number of points used for polyline segmentation. API: 200
+        "distinct_points": "true"
+    }
+    return base_url, base_params

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -67,14 +67,16 @@ class SwissLocatorPlugin:
             self.iface.registerLocatorFilter(self.locator_filters[-1])
             self.locator_filters[-1].message_emitted.connect(self.show_message)
 
-        QgsApplication.profileSourceRegistry().registerProfileSource(self.profile_source)
+        if Qgis.QGIS_VERSION_INT >= 33700:
+            QgsApplication.profileSourceRegistry().registerProfileSource(self.profile_source)
 
     def unload(self):
         for locator_filter in self.locator_filters:
             locator_filter.message_emitted.disconnect(self.show_message)
             self.iface.deregisterLocatorFilter(locator_filter)
 
-        QgsApplication.profileSourceRegistry().unregisterProfileSource(self.profile_source)
+        if Qgis.QGIS_VERSION_INT >= 33700:
+            QgsApplication.profileSourceRegistry().unregisterProfileSource(self.profile_source)
 
     def show_message(
         self, title: str, msg: str, level: Qgis.MessageLevel, widget: QWidget = None

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -36,7 +36,11 @@ from swiss_locator.core.filters.swiss_locator_filter_wmts import SwissLocatorFil
 from swiss_locator.core.filters.swiss_locator_filter_vector_tiles import (
     SwissLocatorFilterVectorTiles,
 )
-from swiss_locator.core.profiles.profile_generator import SwissProfileSource
+try:
+    from swiss_locator.core.profiles.profile_generator import SwissProfileSource
+except ImportError:
+    # Should fail only for QGIS < 3.26, where profiles weren't available
+    SwissProfileSource = None
 
 
 class SwissLocatorPlugin:
@@ -53,7 +57,10 @@ class SwissLocatorPlugin:
         QCoreApplication.installTranslator(self.translator)
 
         self.locator_filters = []
-        self.profile_source = SwissProfileSource()
+
+        if Qgis.QGIS_VERSION_INT >= 33700:
+            # Only on QGIS 3.37+ we'll be able to register profile sources
+            self.profile_source = SwissProfileSource()
 
     def initGui(self):
         for _filter in (

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -20,7 +20,7 @@
 import os
 from PyQt5.QtCore import QCoreApplication, QLocale, QSettings, QTranslator
 from PyQt5.QtWidgets import QWidget
-from qgis.core import Qgis, NULL
+from qgis.core import Qgis, QgsApplication, NULL
 from qgis.gui import QgisInterface, QgsMessageBarItem
 
 from swiss_locator.core.filters.swiss_locator_filter_feature import (
@@ -36,6 +36,7 @@ from swiss_locator.core.filters.swiss_locator_filter_wmts import SwissLocatorFil
 from swiss_locator.core.filters.swiss_locator_filter_vector_tiles import (
     SwissLocatorFilterVectorTiles,
 )
+from swiss_locator.core.profiles.profile_generator import SwissProfileSource
 
 
 class SwissLocatorPlugin:
@@ -52,6 +53,7 @@ class SwissLocatorPlugin:
         QCoreApplication.installTranslator(self.translator)
 
         self.locator_filters = []
+        self.profile_source = SwissProfileSource()
 
     def initGui(self):
         for _filter in (
@@ -65,10 +67,14 @@ class SwissLocatorPlugin:
             self.iface.registerLocatorFilter(self.locator_filters[-1])
             self.locator_filters[-1].message_emitted.connect(self.show_message)
 
+        QgsApplication.profileSourceRegistry().registerProfileSource(self.profile_source)
+
     def unload(self):
         for locator_filter in self.locator_filters:
             locator_filter.message_emitted.disconnect(self.show_message)
             self.iface.deregisterLocatorFilter(locator_filter)
+
+        QgsApplication.profileSourceRegistry().unregisterProfileSource(self.profile_source)
 
     def show_message(
         self, title: str, msg: str, level: Qgis.MessageLevel, widget: QWidget = None

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -20,7 +20,7 @@
 import os
 from PyQt5.QtCore import QCoreApplication, QLocale, QSettings, QTranslator
 from PyQt5.QtWidgets import QWidget
-from qgis.core import Qgis, QgsApplication, NULL
+from qgis.core import Qgis, QgsApplication, QgsMessageLog, NULL
 from qgis.gui import QgisInterface, QgsMessageBarItem
 
 from swiss_locator.core.filters.swiss_locator_filter_feature import (
@@ -76,6 +76,11 @@ class SwissLocatorPlugin:
 
         if Qgis.QGIS_VERSION_INT >= 33700:
             QgsApplication.profileSourceRegistry().registerProfileSource(self.profile_source)
+            QgsMessageLog.logMessage(
+                "Swiss profile source has been registered!",
+                "Swiss locator",
+                Qgis.Info
+            )
 
     def unload(self):
         for locator_filter in self.locator_filters:
@@ -84,6 +89,11 @@ class SwissLocatorPlugin:
 
         if Qgis.QGIS_VERSION_INT >= 33700:
             QgsApplication.profileSourceRegistry().unregisterProfileSource(self.profile_source)
+            QgsMessageLog.logMessage(
+                "Swiss profile source has been unregistered!",
+                "Swiss locator",
+                Qgis.Info
+            )
 
     def show_message(
         self, title: str, msg: str, level: Qgis.MessageLevel, widget: QWidget = None


### PR DESCRIPTION
Pending:
 + [x] Line/polygon symbology.
 + [x] Profile visible in Layout.
 + [x] Export 3d (x, y, z).
 + [x] Export 2d (distance, z).
 + [x] Export distance/elevation table.
 + [x] Snap to profile results.
 + [x] Bug in EPSG:3857: Displaced profile (`wontfix` for now).
     + Note there is a QGIS bug [here](https://github.com/qgis/QGIS/issues/48270) and a related bug [here](https://github.com/PANOimagen/profiletool/issues/65)).
 + [x] Layer tree node (only in a follow-up).
 + [x] Identify: Does not apply (no features on the main canvas to get attributes from)


https://github.com/opengisch/qgis-swiss-locator/assets/652785/14b380a6-a741-4ded-a38c-4737688148e4
