### PR TITLE
Make sure map tips are not shown if QtWebKit is not installed

### DIFF
--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -61,6 +61,7 @@ from swiss_locator.core.settings import Settings
 from swiss_locator.core.language import get_language
 from swiss_locator.gui.config_dialog import ConfigDialog
 from swiss_locator.gui.maptip import MapTip
+from swiss_locator.gui.qtwebkit_conf import with_qt_web_kit
 
 
 def result_from_data(result: QgsLocatorResult):
@@ -428,7 +429,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             point = QgsGeometry.fromPointXY(swiss_result.point)
             point.transform(self.transform_4326)
             self.highlight(point)
-            if self.settings.value("show_map_tip"):
+            if self.settings.value("show_map_tip") and with_qt_web_kit():
                 self.show_map_tip(swiss_result.layer, swiss_result.feature_id, point)
 
         # Vector tiles
@@ -525,7 +526,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             if layer and feature_id:
                 self.fetch_feature(layer, feature_id)
 
-                if self.settings.value("show_map_tip"):
+                if self.settings.value("show_map_tip") and with_qt_web_kit():
                     self.show_map_tip(layer, feature_id, point)
             else:
                 self.current_timer = QTimer()

--- a/swiss_locator/gui/config_dialog.py
+++ b/swiss_locator/gui/config_dialog.py
@@ -31,6 +31,7 @@ from ..qgissettingmanager.setting_dialog import SettingDialog, UpdateMode
 from ..core.settings import Settings
 from ..core.language import get_language
 from ..map_geo_admin.layers import searchable_layers
+from .qtwebkit_conf import with_qt_web_kit
 
 DialogUi, _ = loadUiType(os.path.join(os.path.dirname(__file__), "../ui/config.ui"))
 
@@ -54,11 +55,12 @@ class ConfigDialog(QDialog, DialogUi, SettingDialog):
             self.lang.addItem(key, val)
         for filter_type in FilterType:
             cb = self.findChild(QComboBox, "{}_priority".format(filter_type.value))
-            cb.addItem(self.tr("Highest"), QgsLocatorFilter.Highest)
-            cb.addItem(self.tr("High"), QgsLocatorFilter.High)
-            cb.addItem(self.tr("Medium"), QgsLocatorFilter.Medium)
-            cb.addItem(self.tr("Low"), QgsLocatorFilter.Low)
-            cb.addItem(self.tr("Lowest"), QgsLocatorFilter.Lowest)
+            if cb is not None:  # Some filters might not have a config dialog
+                cb.addItem(self.tr("Highest"), QgsLocatorFilter.Highest)
+                cb.addItem(self.tr("High"), QgsLocatorFilter.High)
+                cb.addItem(self.tr("Medium"), QgsLocatorFilter.Medium)
+                cb.addItem(self.tr("Low"), QgsLocatorFilter.Low)
+                cb.addItem(self.tr("Lowest"), QgsLocatorFilter.Lowest)
 
         self.crs.addItem(
             self.tr("Use map CRS if possible, defaults to CH1903+"), "project"
@@ -96,6 +98,11 @@ class ConfigDialog(QDialog, DialogUi, SettingDialog):
 
         self.settings = settings
         self.init_widgets()
+
+        if not with_qt_web_kit():
+            map_tip = self.setting_widget("show_map_tip")
+            map_tip.widget.setEnabled(False)
+            map_tip.widget.setToolTip(self.tr("You need to install QtWebKit to use map tips."))
 
     def select_all(self, select: bool = True):
         for r in range(self.feature_search_layers_list.rowCount()):

--- a/swiss_locator/gui/maptip.py
+++ b/swiss_locator/gui/maptip.py
@@ -22,14 +22,16 @@
 """
 
 from PyQt5.QtCore import Qt, QPoint, pyqtSignal
-from PyQt5.QtWebKit import QWebSettings
-from PyQt5.QtWebKitWidgets import QWebView, QWebPage
 from PyQt5.QtWidgets import QSizePolicy, QDockWidget
 from PyQt5.QtGui import QPalette, QDesktopServices, QCloseEvent
 from qgis.core import Qgis, QgsPointXY, QgsMessageLog
 from qgis.gui import QgisInterface
 
 from swiss_locator import DEBUG
+from swiss_locator.gui.qtwebkit_conf import with_qt_web_kit
+if with_qt_web_kit():
+    from PyQt5.QtWebKit import QWebSettings
+    from PyQt5.QtWebKitWidgets import QWebView, QWebPage
 
 
 class MapTip(QDockWidget):

--- a/swiss_locator/gui/qtwebkit_conf.py
+++ b/swiss_locator/gui/qtwebkit_conf.py
@@ -1,0 +1,16 @@
+
+_WITH_QTWEBKIT = None
+
+
+def with_qt_web_kit() -> bool:
+    global _WITH_QTWEBKIT
+    if _WITH_QTWEBKIT is None:
+        try:
+            from PyQt5.QtWebKit import QWebSettings
+            from PyQt5.QtWebKitWidgets import QWebView, QWebPage
+        except ModuleNotFoundError:
+            _WITH_QTWEBKIT = False
+        else:
+            _WITH_QTWEBKIT = True
+
+    return _WITH_QTWEBKIT


### PR DESCRIPTION
 If that's the case, disable map tips and its correspondant widget, showing a nice tooltip.

![image](https://github.com/opengisch/qgis-swiss-locator/assets/652785/d8e71674-4a9c-4cc9-a0cc-7c42a8e23c1a)

Fix #57
Fix #81