### PR TITLE
[wmts] Check that we've got a file path before attempting to parse it

### DIFF
--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -22,6 +22,7 @@ from qgis.PyQt.QtNetwork import QNetworkRequest
 
 from qgis.gui import QgisInterface
 from qgis.core import (
+    Qgis,
     QgsApplication,
     QgsBlockingNetworkRequest,
     QgsFetchedContent,
@@ -96,6 +97,11 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
                 f"Swisstopo capabilities has been downloaded. Reading from {self.content.filePath()}"
             )
             self.capabilities = ET.parse(self.content.filePath()).getroot()
+        else:
+            self.info(
+                "The Swiss Locator filter for WMTS layers could not fetch capabilities",
+                Qgis.Critical
+            )
 
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
         namespaces = {

--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -55,7 +55,7 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
 
             self.info(self.content.status())
 
-            if self.content.status() == QgsFetchedContent.ContentStatus.Finished:
+            if self.content.status() == QgsFetchedContent.ContentStatus.Finished and self.content.filePath():
                 file_path = self.content.filePath()
                 self.info(
                     f"Swisstopo capabilities already downloaded. Reading from {file_path}"
@@ -91,7 +91,7 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
         return "chw"
 
     def handle_capabilities_response(self):
-        if self.content.status() == QgsFetchedContent.ContentStatus.Finished:
+        if self.content.status() == QgsFetchedContent.ContentStatus.Finished and self.content.filePath():
             self.info(
                 f"Swisstopo capabilities has been downloaded. Reading from {self.content.filePath()}"
             )


### PR DESCRIPTION
Fix #51 


**Note:**
I've been unable to replicate the issue.
QGIS has specific tests that verify that a `filePath()` is always set along with a `QgsFetchedContent.ContentStatus.Finished` status. See https://github.com/qgis/QGIS/blob/166f326b3324d555af80d1b1b3a9c23f028955b5/tests/src/python/test_qgsnetworkcontentfetcherregistry.py#L81


However, I've added a double check here (QGIS [seems to do the same](https://github.com/qgis/QGIS/blob/166f326b3324d555af80d1b1b3a9c23f028955b5/src/core/network/qgsnetworkcontentfetcherregistry.cpp#L97)) to avoid attempting to parse the file if `filePath()` is empty, so we won't never get the error.