### PR TITLE
Avoid unnecessary Capabilities requests

### DIFF
--- a/swiss_locator/core/filters/swiss_locator_filter_layer.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_layer.py
@@ -118,12 +118,12 @@ class SwissLocatorFilterLayer(SwissLocatorFilter):
                         ):
                             self.dbg_info(f"get_cap: {url_components.netloc} {url}")
                             visited_capabilities.append(url_components.netloc)
-                        self.fetch_request(
-                            QNetworkRequest(QUrl(url)),
-                            feedback,
-                            slot=self.handle_capabilities_response,
-                            data=(search, wms_url),
-                        )
+                            self.fetch_request(
+                                QNetworkRequest(QUrl(url)),
+                                feedback,
+                                slot=self.handle_capabilities_response,
+                                data=(search, wms_url),
+                            )
 
         else:
             for loc in data["results"]:


### PR DESCRIPTION
While parsing Opendata Swiss responses, we have a [too broad condition](https://github.com/opengisch/qgis-swiss-locator/blob/0bfeeaf4dab150f473818dc65a12e5d9a88a3a7c/swiss_locator/core/filters/swiss_locator_filter_layer.py#L99) (`if "wms" in url.lower()`) leading the plugin to go for resources like:

```
Title: WMS-Layer als Hintergrundkarten laden
Url: https://www.envidat.ch/dataset/seilaplan-tutorial-wms-layer-als-hintergrundkarten-laden/resource/18d13f78-0149-42bc-b962-fdd7bd972e4d
format: SERVICE
```

After this broad condition, I see there might be a code block with a wrong indentation, which makes the plugin always go for the resource (whose content in this case is malformed, thus the exception) as a WMS Capabilities resource, even if the resource didn't match [another condition](https://github.com/opengisch/qgis-swiss-locator/blob/0bfeeaf4dab150f473818dc65a12e5d9a88a3a7c/swiss_locator/core/filters/swiss_locator_filter_layer.py#L115-L118) to be treated as a Capabilities one.

I guess it's a matter of fixing the indentation of this block to only perform the Capabilities request if it did match the aforementioned condition.

Fix #83