### PR TITLE
Switch from ellipsoidal to 2d cartesian distances

### DIFF
--- a/swiss_locator/core/profiles/profile_results.py
+++ b/swiss_locator/core/profiles/profile_results.py
@@ -22,9 +22,11 @@ class SwissProfileResults(QgsAbstractProfileResults):
 
         self.__profile_curve = None
         self.raw_points = []  # QgsPointSequence
-        self.distance_to_height = {}
+        self.cartesian_distance_to_height = {}
+        self.ellipsoidal_distance_to_height = {}
         self.geometries = []
-        self.cross_section_geometries = []
+        self.cartesian_cross_section_geometries = []
+        self.ellipsoidal_cross_section_geometries = []
         self.min_z = 4500
         self.max_z = -100
 
@@ -55,7 +57,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
                 result.append(feature)
 
         elif type == Qgis.ProfileExportType.Profile2D:
-            for geom in self.cross_section_geometries:
+            for geom in self.cartesian_cross_section_geometries:
                 feature = QgsAbstractProfileResults.Feature()
                 feature.geometry = geom
                 feature.layerIdentifier = self.type()
@@ -70,7 +72,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
                 # Since we've got distance/elevation pairs as
                 # x,y for cross-section geometries, and since
                 # both point arrays have the same length:
-                p = self.cross_section_geometries[i].asPoint()
+                p = self.cartesian_cross_section_geometries[i].asPoint()
                 feature.attributes = {"distance": p.x(), "elevation": p.y()}
                 result.append(feature)
 
@@ -93,7 +95,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
 
         prev_distance = float('inf')
         prev_elevation = 0
-        for k, v in self.distance_to_height.items():
+        for k, v in self.cartesian_distance_to_height.items():
             # find segment which corresponds to the given distance along curve
             if k != 0 and prev_distance <= point.distance() <= k:
                 dx = k - prev_distance
@@ -159,7 +161,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
         current_line = QPolygonF()
         prev_distance = None
         current_part_start_distance = 0
-        for k, v in self.distance_to_height.items():
+        for k, v in self.cartesian_distance_to_height.items():
             if not len(current_line):  # new part
                 if not v:  # skip emptiness
                     continue
@@ -200,7 +202,7 @@ class SwissProfileResults(QgsAbstractProfileResults):
 
         self.marker_symbol.startRender(context.renderContext())
 
-        for k, v in self.distance_to_height.items():
+        for k, v in self.cartesian_distance_to_height.items():
             if not v:
                 continue
 


### PR DESCRIPTION
Because that's what QGIS elevation profile tool supports.

By doing so, we ensure users won't get displaced profile graphs (too much difference between ellipsoidal and cartesian distances) nor displaced exported features (using 3d cartesian distances, exported features won't match in the graph and will be displaced with respect to 2d distances calculated by the elevation profile tool).

![image](https://github.com/opengisch/qgis-swiss-locator/assets/652785/15a8a656-1510-4585-b09e-ac96b81c64c9)

Fix #86 
Fix #87 


-----------------

For the record, this is the deviation when using 3d cartesian distances:
Points are exported features (distance/elevation table) from the profile, which have their Z coordinate. The elevation profile tool doesn't take these Z coordinates into account when calculating distances, so features appear displaced with respect to its correspondent 3d cartesian distance given by the Swiss locator calculation. As a result, we use 2d cartesian distances avoiding these displacements. 

![image](https://github.com/opengisch/qgis-swiss-locator/assets/652785/a7957dd2-d1b7-40d0-9f21-8ffdb5e9582a)
