### PR TITLE
support for Qt 6 builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: docker test
         run: |
-          docker run -v $(pwd):/usr/src -w /usr/src opengisch/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3'
+          docker run -v $(pwd):/usr/src -w /usr/src qgis/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: docker test
         run: |
-          docker run -v $(pwd):/usr/src -w /usr/src opengisch/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3 --ignore-glob=**/qgissettingmanager/*'
+          docker run -v $(pwd):/usr/src -w /usr/src opengisch/qgis:${QGIS_TEST_VERSION} sh -c 'xvfb-run pytest-3'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "swiss_locator/qgissettingmanager"]
-	path = swiss_locator/qgissettingmanager
-	url = git@github.com:opengisch/qgis_setting_manager.git

--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -31,6 +31,7 @@ from qgis.PyQt.QtCore import QUrl, pyqtSignal, QEventLoop
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply, QNetworkAccessManager
 
 from qgis.core import (
+    metaEnumFromType,
     Qgis,
     QgsLocatorFilter,
     QgsLocatorResult,
@@ -120,6 +121,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
         self.result_found = False
         self.access_managers = {}
         self.minimum_search_length = 2
+        self.me = metaEnumFromType(QgsLocatorFilter.Priority)
 
         self.nam = QNetworkAccessManager()
         self.nam.setRedirectPolicy(
@@ -161,7 +163,13 @@ class SwissLocatorFilter(QgsLocatorFilter):
         return self.__class__.__name__
 
     def priority(self):
-        return QgsLocatorFilter.Priority.Medium
+        (value, ok) = self.me.keyToValue(
+            self.settings.filters[self.type.value]["priority"].value()
+        )
+        if ok:
+            return QgsLocatorFilter.Priority(value)
+        else:
+            return QgsLocatorFilter.Priority.Medium
 
     def displayName(self):
         # this should be re-implemented

--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -120,7 +120,9 @@ class SwissLocatorFilter(QgsLocatorFilter):
         self.minimum_search_length = 2
 
         self.nam = QNetworkAccessManager()
-        self.nam.setRedirectPolicy(QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy)
+        self.nam.setRedirectPolicy(
+            QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy
+        )
         self.network_replies = dict()
 
         if crs:
@@ -133,7 +135,9 @@ class SwissLocatorFilter(QgsLocatorFilter):
             self.map_canvas = iface.mapCanvas()
             self.map_canvas.destinationCrsChanged.connect(self.create_transforms)
 
-            self.rubber_band = QgsRubberBand(self.map_canvas, QgsWkbTypes.GeometryType.PointGeometry)
+            self.rubber_band = QgsRubberBand(
+                self.map_canvas, QgsWkbTypes.GeometryType.PointGeometry
+            )
             self.rubber_band.setColor(QColor(255, 255, 50, 200))
             self.rubber_band.setIcon(self.rubber_band.ICON_CIRCLE)
             self.rubber_band.setIconSize(15)
@@ -155,7 +159,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
         return self.__class__.__name__
 
     def priority(self):
-        return self.settings.value(f"{self.type.value}_priority")
+        return QgsLocatorFilter.Priority.Medium
 
     def displayName(self):
         # this should be re-implemented
@@ -185,20 +189,20 @@ class SwissLocatorFilter(QgsLocatorFilter):
 
     def openConfigWidget(self, parent=None):
         dlg = ConfigDialog(parent)
-        wid = dlg.findChild(QTabWidget, "tabWidget", Qt.FindChildOption.FindDirectChildrenOnly)
+        wid = dlg.findChild(
+            QTabWidget, "tabWidget", Qt.FindChildOption.FindDirectChildrenOnly
+        )
         tab = wid.findChild(QWidget, self.type.value)
         wid.setCurrentWidget(tab)
         dlg.exec()
 
     def create_transforms(self):
         # this should happen in the main thread
-        self.crs = self.settings.value("crs")
-        if self.crs == "project":
-            map_crs = self.map_canvas.mapSettings().destinationCrs()
-            if map_crs.isValid() and ":" in map_crs.authid():
-                self.crs = map_crs.authid().split(":")[1]
-            if self.crs not in AVAILABLE_CRS:
-                self.crs = "2056"
+        map_crs = self.map_canvas.mapSettings().destinationCrs()
+        if map_crs.isValid() and ":" in map_crs.authid():
+            self.crs = map_crs.authid().split(":")[1]
+        if self.crs not in AVAILABLE_CRS:
+            self.crs = "2056"
         assert self.crs in AVAILABLE_CRS
         src_crs_ch = QgsCoordinateReferenceSystem("EPSG:{}".format(self.crs))
         assert src_crs_ch.isValid()
@@ -421,7 +425,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             point = QgsGeometry.fromPointXY(swiss_result.point)
             point.transform(self.transform_4326)
             self.highlight(point)
-            if self.settings.value("show_map_tip") and with_qt_web_kit():
+            if self.settings.show_map_tip.value() and with_qt_web_kit():
                 self.show_map_tip(swiss_result.layer, swiss_result.feature_id, point)
 
         # Vector tiles
@@ -519,7 +523,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             if layer and feature_id:
                 self.fetch_feature(layer, feature_id)
 
-                if self.settings.value("show_map_tip") and with_qt_web_kit():
+                if self.settings.show_map_tip.value() and with_qt_web_kit():
                     self.show_map_tip(layer, feature_id, point)
             else:
                 self.current_timer = QTimer()

--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -61,8 +61,7 @@ from swiss_locator.core.results import (
 from swiss_locator.core.settings import Settings
 from swiss_locator.core.language import get_language
 
-if Qgis.QGIS_VERSION_INT >= 33900:
-    from swiss_locator.gui.config_dialog import ConfigDialog
+from swiss_locator.gui.config_dialog import ConfigDialog
 from swiss_locator.gui.maptip import MapTip
 from swiss_locator.gui.qtwebkit_conf import with_qt_web_kit
 from swiss_locator.utils.utils import url_with_param
@@ -195,7 +194,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             self.current_timer = None
 
     def hasConfigWidget(self):
-        return Qgis.QGIS_VERSION_INT >= 33900
+        return True
 
     def openConfigWidget(self, parent=None):
         dlg = ConfigDialog(parent)

--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -59,7 +59,9 @@ from swiss_locator.core.results import (
 )
 from swiss_locator.core.settings import Settings
 from swiss_locator.core.language import get_language
-from swiss_locator.gui.config_dialog import ConfigDialog
+
+if Qgis.QGIS_VERSION_INT >= 33900:
+    from swiss_locator.gui.config_dialog import ConfigDialog
 from swiss_locator.gui.maptip import MapTip
 from swiss_locator.gui.qtwebkit_conf import with_qt_web_kit
 from swiss_locator.utils.utils import url_with_param
@@ -185,7 +187,7 @@ class SwissLocatorFilter(QgsLocatorFilter):
             self.current_timer = None
 
     def hasConfigWidget(self):
-        return True
+        return Qgis.QGIS_VERSION_INT >= 33900
 
     def openConfigWidget(self, parent=None):
         dlg = ConfigDialog(parent)

--- a/swiss_locator/core/filters/swiss_locator_filter_feature.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_feature.py
@@ -53,12 +53,15 @@ class SwissLocatorFilterFeature(SwissLocatorFilter):
     def prefix(self):
         return "chf"
 
+    def priority(self):
+        return self.settings.filter_feature_priority.value()
+
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
         # Feature search is split in several requests
         # otherwise URL is too long
         requests = []
         try:
-            limit = self.settings.value(f"{FilterType.Feature.value}_limit")
+            limit = self.settings.filter_feature_limit.value()
             layers = list(self.searchable_layers.keys())
             assert len(layers) > 0
             step = 20

--- a/swiss_locator/core/filters/swiss_locator_filter_feature.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_feature.py
@@ -53,9 +53,6 @@ class SwissLocatorFilterFeature(SwissLocatorFilter):
     def prefix(self):
         return "chf"
 
-    def priority(self):
-        return self.settings.filter_feature_priority.value()
-
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
         # Feature search is split in several requests
         # otherwise URL is too long

--- a/swiss_locator/core/filters/swiss_locator_filter_layer.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_layer.py
@@ -52,8 +52,11 @@ class SwissLocatorFilterLayer(SwissLocatorFilter):
     def prefix(self):
         return "chl"
 
+    def priority(self):
+        return self.settings.filter_layers_priority.value()
+
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
-        limit = self.settings.value(f"{FilterType.Location.value}_limit")
+        limit = self.settings.filter_layers_limit.value()
         urls = [
             map_geo_admin_url(search, self.type.value, self.crs, self.lang, limit),
             opendata_swiss_url(search),

--- a/swiss_locator/core/filters/swiss_locator_filter_layer.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_layer.py
@@ -52,9 +52,6 @@ class SwissLocatorFilterLayer(SwissLocatorFilter):
     def prefix(self):
         return "chl"
 
-    def priority(self):
-        return self.settings.filter_layers_priority.value()
-
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
         limit = self.settings.filter_layers_limit.value()
         urls = [

--- a/swiss_locator/core/filters/swiss_locator_filter_location.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_location.py
@@ -57,9 +57,6 @@ class SwissLocatorFilterLocation(SwissLocatorFilter):
     def prefix(self):
         return "chs"
 
-    def priority(self):
-        return self.settings.filter_location_priority.value()
-
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
         limit = self.settings.filter_location_limit.value()
         url, params = map_geo_admin_url(

--- a/swiss_locator/core/filters/swiss_locator_filter_location.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_location.py
@@ -57,8 +57,11 @@ class SwissLocatorFilterLocation(SwissLocatorFilter):
     def prefix(self):
         return "chs"
 
+    def priority(self):
+        return self.settings.filter_location_priority.value()
+
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
-        limit = self.settings.value(f"{FilterType.Location.value}_limit")
+        limit = self.settings.filter_location_limit.value()
         url, params = map_geo_admin_url(
             search, self.type.value, self.crs, self.lang, limit
         )

--- a/swiss_locator/core/filters/swiss_locator_filter_vector_tiles.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_vector_tiles.py
@@ -27,9 +27,6 @@ class SwissLocatorFilterVectorTiles(SwissLocatorFilter):
     def prefix(self):
         return "chb"
 
-    def priority(self):
-        return self.settings.filter_vt_priority.value()
-
     def hasConfigWidget(self):
         return False
 

--- a/swiss_locator/core/filters/swiss_locator_filter_vector_tiles.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_vector_tiles.py
@@ -1,8 +1,6 @@
 from qgis.gui import QgisInterface
 from qgis.core import (
     QgsApplication,
-    QgsBlockingNetworkRequest,
-    QgsFetchedContent,
     QgsLocatorResult,
     QgsFeedback,
 )
@@ -29,6 +27,9 @@ class SwissLocatorFilterVectorTiles(SwissLocatorFilter):
     def prefix(self):
         return "chb"
 
+    def priority(self):
+        return self.settings.filter_vt_priority.value()
+
     def hasConfigWidget(self):
         return False
 
@@ -38,27 +39,31 @@ class SwissLocatorFilterVectorTiles(SwissLocatorFilter):
                 "title": "Base map",
                 "description": "",
                 "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.base.vt/v1.0.0/{z}/{x}/{y}.pbf",
-                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json"
+                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.basemap.vt/style.json",
             },
             "light base map": {
-                "title": "Light base map", "description": "",
+                "title": "Light base map",
+                "description": "",
                 "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.base.vt/v1.0.0/{z}/{x}/{y}.pbf",
-                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.lightbasemap.vt/style.json"
+                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.lightbasemap.vt/style.json",
             },
             "imagery base map": {
-                "title": "Imagery base map", "description": "",
+                "title": "Imagery base map",
+                "description": "",
                 "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.base.vt/v1.0.0/{z}/{x}/{y}.pbf",
-                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.imagerybasemap.vt/style.json"
+                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.imagerybasemap.vt/style.json",
             },
             "leichte-basiskarte": {
-                "title": "leichte-basiskarte", "description": "",
+                "title": "leichte-basiskarte",
+                "description": "",
                 "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.leichte-basiskarte.vt/v3.0.1/{z}/{x}/{y}.pbf",
-                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.leichte-basiskarte.vt/style.json"
+                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.leichte-basiskarte.vt/style.json",
             },
             "leichte-basiskarte-imagery": {
-                "title": "leichte-basiskarte-imagery", "description": "",
+                "title": "leichte-basiskarte-imagery",
+                "description": "",
                 "url": "https://vectortiles.geo.admin.ch/tiles/ch.swisstopo.leichte-basiskarte.vt/v3.0.1/{z}/{x}/{y}.pbf",
-                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.leichte-basiskarte-imagery.vt/style.json"
+                "style": "https://vectortiles.geo.admin.ch/styles/ch.swisstopo.leichte-basiskarte-imagery.vt/style.json",
             },
         }
 
@@ -68,7 +73,9 @@ class SwissLocatorFilterVectorTiles(SwissLocatorFilter):
             if not search or search.lower() in keyword:
                 result = QgsLocatorResult()
                 result.filter = self
-                result.icon = QgsApplication.getThemeIcon("/mActionAddVectorTileLayer.svg")
+                result.icon = QgsApplication.getThemeIcon(
+                    "/mActionAddVectorTileLayer.svg"
+                )
 
                 result.displayString = data[keyword]["title"]
                 result.description = data[keyword]["description"]
@@ -82,7 +89,7 @@ class SwissLocatorFilterVectorTiles(SwissLocatorFilter):
                 results[result] = score
 
             # sort the results with score
-            #results = sorted([result for (result, score) in results.items()])
+            # results = sorted([result for (result, score) in results.items()])
 
             for result in results:
                 self.resultFetched.emit(result)

--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -56,7 +56,10 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
 
             self.info(self.content.status())
 
-            if self.content.status() == QgsFetchedContent.ContentStatus.Finished and self.content.filePath():
+            if (
+                self.content.status() == QgsFetchedContent.ContentStatus.Finished
+                and self.content.filePath()
+            ):
                 file_path = self.content.filePath()
                 self.info(
                     f"Swisstopo capabilities already downloaded. Reading from {file_path}"
@@ -73,7 +76,8 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
             nam.get(request, forceRefresh=True)
             reply = nam.reply()
             if (
-                reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute) == 200
+                reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+                == 200
             ):  # other codes are handled by NetworkAccessManager
                 self.capabilities = ET.fromstring(reply.content().data().decode("utf8"))
             else:
@@ -91,8 +95,14 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
     def prefix(self):
         return "chw"
 
+    def priority(self):
+        return self.settings.filter_wmts_priority.value()
+
     def handle_capabilities_response(self):
-        if self.content.status() == QgsFetchedContent.ContentStatus.Finished and self.content.filePath():
+        if (
+            self.content.status() == QgsFetchedContent.ContentStatus.Finished
+            and self.content.filePath()
+        ):
             self.info(
                 f"Swisstopo capabilities has been downloaded. Reading from {self.content.filePath()}"
             )
@@ -100,7 +110,7 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
         else:
             self.info(
                 "The Swiss Locator filter for WMTS layers could not fetch capabilities",
-                Qgis.MessageLevel.Critical
+                Qgis.MessageLevel.Critical,
             )
 
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
@@ -170,6 +180,6 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
             # sort the results with score
             results = sorted([result for (result, score) in results.items()])
 
-            for result in results[0 : self.settings.value("wmts_limit")]:
+            for result in results[0 : self.settings.filter_wmts_limit.value()]:
                 self.resultFetched.emit(result)
                 self.result_found = True

--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -95,9 +95,6 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
     def prefix(self):
         return "chw"
 
-    def priority(self):
-        return self.settings.filter_wmts_priority.value()
-
     def handle_capabilities_response(self):
         if (
             self.content.status() == QgsFetchedContent.ContentStatus.Finished

--- a/swiss_locator/core/language.py
+++ b/swiss_locator/core/language.py
@@ -27,6 +27,7 @@
 from qgis.PyQt.QtCore import QLocale, QSettings
 from .settings import Settings
 from qgis.core import NULL
+from .parameters import AVAILABLE_LANGUAGES
 
 
 def get_language() -> str:
@@ -36,17 +37,13 @@ def get_language() -> str:
     :return: 2 chars long string representing the language to be used
     """
     # get lang from settings
-    lang = Settings().value("lang")
+    lang = Settings().lang.value()
     if not lang:
-        # if None, try to use the locale one
-        from .parameters import AVAILABLE_LANGUAGES
-
         locale = str(QSettings().value("locale/userLocale")).replace(str(NULL), "en_CH")
         locale_lang = QLocale.languageToString(QLocale(locale).language())
         if locale_lang in AVAILABLE_LANGUAGES:
             lang = AVAILABLE_LANGUAGES[locale_lang]
-        else:
-            # defaults to English
-            lang = "en"
+    if lang not in AVAILABLE_LANGUAGES:
+        lang = "en"
 
     return lang

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -25,11 +25,11 @@
 # ---------------------------------------------------------------------
 
 from qgis.core import (
+    metaEnumFromType,
     QgsLocatorFilter,
     QgsSettingsTree,
     QgsSettingsEntryBool,
     QgsSettingsEntryString,
-    QgsSettingsEntryEnumFlag,
     QgsSettingsEntryInteger,
     QgsSettingsEntryStringList,
 )
@@ -61,49 +61,59 @@ class Settings(object):
                 "feature_search_layers_list", settings_node, []
             )
 
-            cls.filter_location_priority = QgsSettingsEntryEnumFlag(
-                f"{FilterType.Location.value}_priority",
-                settings_node,
-                QgsLocatorFilter.Priority.Highest,
-            )
-            cls.filter_location_limit = QgsSettingsEntryInteger(
-                f"{FilterType.Location.value}_limit", settings_node, 8
-            )
+            me = metaEnumFromType(QgsLocatorFilter.Priority)
 
-            cls.filter_wmts_priority = QgsSettingsEntryEnumFlag(
-                f"{FilterType.WMTS.value}_priority",
-                settings_node,
-                QgsLocatorFilter.Priority.Medium,
-            )
-            cls.filter_wmts_limit = QgsSettingsEntryInteger(
-                f"{FilterType.WMTS.value}_limit", settings_node, 8
-            )
-
-            cls.filter_vt_priority = QgsSettingsEntryEnumFlag(
-                f"{FilterType.VectorTiles.value}_priority",
-                settings_node,
-                QgsLocatorFilter.Priority.Highest,
-            )
-            cls.filter_vt_limit = QgsSettingsEntryInteger(
-                f"{FilterType.VectorTiles.value}_limit", settings_node, 8
-            )
-
-            cls.filter_feature_priority = QgsSettingsEntryEnumFlag(
-                f"{FilterType.Feature.value}_priority",
-                settings_node,
-                QgsLocatorFilter.Priority.High,
-            )
-            cls.filter_feature_limit = QgsSettingsEntryInteger(
-                f"{FilterType.Feature.value}_limit", settings_node, 8
-            )
-
-            cls.filter_layers_priority = QgsSettingsEntryEnumFlag(
-                f"{FilterType.Layers.value}_priority",
-                settings_node,
-                QgsLocatorFilter.Priority.High,
-            )
-            cls.filter_layers_limit = QgsSettingsEntryInteger(
-                f"{FilterType.Layers.value}_limit", settings_node, 5
-            )
+            cls.filters = {
+                FilterType.Location.value: {
+                    "priority": QgsSettingsEntryString(
+                        f"{FilterType.Location.value}_priority",
+                        settings_node,
+                        me.valueToKey(QgsLocatorFilter.Priority.Highest),
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                        f"{FilterType.Location.value}_limit", settings_node, 8
+                    ),
+                },
+                FilterType.WMTS.value: {
+                    "priority": QgsSettingsEntryString(
+                        f"{FilterType.WMTS.value}_priority",
+                        settings_node,
+                        me.valueToKey(QgsLocatorFilter.Priority.Medium),
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                        f"{FilterType.WMTS.value}_limit", settings_node, 8
+                    ),
+                },
+                FilterType.VectorTiles.value: {
+                    "priority": QgsSettingsEntryString(
+                        f"{FilterType.VectorTiles.value}_priority",
+                        settings_node,
+                        me.valueToKey(QgsLocatorFilter.Priority.Highest),
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                        f"{FilterType.VectorTiles.value}_limit", settings_node, 8
+                    ),
+                },
+                FilterType.Feature.value: {
+                    "priority": QgsSettingsEntryString(
+                        f"{FilterType.Feature.value}_priority",
+                        settings_node,
+                        me.valueToKey(QgsLocatorFilter.Priority.High),
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                        f"{FilterType.Feature.value}_limit", settings_node, 8
+                    ),
+                },
+                FilterType.Layers.value: {
+                    "priority": QgsSettingsEntryString(
+                        f"{FilterType.Layers.value}_priority",
+                        settings_node,
+                        me.valueToKey(QgsLocatorFilter.Priority.High),
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                        f"{FilterType.Layers.value}_limit", settings_node, 5
+                    ),
+                },
+            }
 
         return cls.instance

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -24,82 +24,86 @@
 #
 # ---------------------------------------------------------------------
 
-
-from qgis.core import QgsLocatorFilter
-from swiss_locator.qgissettingmanager import (
-    SettingManager,
-    Scope,
-    Bool,
-    String,
-    Stringlist,
-    Integer,
-    Enum,
+from qgis.core import (
+    QgsLocatorFilter,
+    QgsSettingsTree,
+    QgsSettingsEntryBool,
+    QgsSettingsEntryString,
+    QgsSettingsEntryEnumFlag,
+    QgsSettingsEntryInteger,
+    QgsSettingsEntryStringList,
 )
 from swiss_locator.core.filters.filter_type import FilterType
 
-pluginName = "swiss_locator_plugin"
+PLUGIN_NAME = "swiss_locator_plugin"
 
 
-class Settings(SettingManager):
-    def __init__(self):
-        SettingManager.__init__(self, pluginName)
+class Settings(object):
+    instance = None
 
-        # lang of the service
-        # possible values are de, fr, it , rm, en
-        # if left empty or NULL, try to use locale and defaults to en
-        self.add_setting(String("lang", Scope.Global, ""))
-        self.add_setting(
-            String(
-                "crs",
-                Scope.Global,
-                "project",
-                allowed_values=("2056", "21781", "project"),
+    def __new__(cls):
+        if cls.instance is None:
+            cls.instance = super(Settings, cls).__new__(cls)
+
+            settings_node = QgsSettingsTree.createPluginTreeNode(pluginName=PLUGIN_NAME)
+
+            cls.lang = QgsSettingsEntryString("lang", settings_node, "lang")
+            cls.show_map_tip = QgsSettingsEntryBool(
+                "show_map_tip", settings_node, False
             )
-        )
-        self.add_setting(Bool("show_map_tip", Scope.Global, False))
+            cls.feature_search_restrict = QgsSettingsEntryBool(
+                "feature_search_restrict", settings_node, False
+            )
+            cls.layers_include_opendataswiss = QgsSettingsEntryBool(
+                "layers_include_opendataswiss", settings_node, True
+            )
+            cls.feature_search_layers_list = QgsSettingsEntryStringList(
+                "feature_search_layers_list", settings_node, []
+            )
 
-        self.add_setting(
-            Enum(
+            cls.filter_location_priority = QgsSettingsEntryEnumFlag(
                 f"{FilterType.Location.value}_priority",
-                Scope.Global,
+                settings_node,
                 QgsLocatorFilter.Priority.Highest,
             )
-        )
-        self.add_setting(Integer(f"{FilterType.Location.value}_limit", Scope.Global, 8))
-        self.add_setting(
-            Enum(
+            cls.filter_location_limit = QgsSettingsEntryInteger(
+                f"{FilterType.Location.value}_limit", settings_node, 8
+            )
+
+            cls.filter_wmts_priority = QgsSettingsEntryEnumFlag(
                 f"{FilterType.WMTS.value}_priority",
-                Scope.Global,
-                QgsLocatorFilter.Priority.Highest,
-            )
-        )
-        self.add_setting(Integer(f"{FilterType.WMTS.value}_limit", Scope.Global, 8))
-        self.add_setting(
-            Enum(
-                f"{FilterType.VectorTiles.value}_priority",
-                Scope.Global,
+                settings_node,
                 QgsLocatorFilter.Priority.Medium,
             )
-        )
-        self.add_setting(Integer(f"{FilterType.VectorTiles.value}_limit", Scope.Global, 8))
-        self.add_setting(
-            Enum(
-                f"{FilterType.Feature.value}_priority",
-                Scope.Global,
+            cls.filter_wmts_limit = QgsSettingsEntryInteger(
+                f"{FilterType.WMTS.value}_limit", settings_node, 8
+            )
+
+            cls.filter_vt_priority = QgsSettingsEntryEnumFlag(
+                f"{FilterType.VectorTiles.value}_priority",
+                settings_node,
                 QgsLocatorFilter.Priority.Highest,
             )
-        )
-        self.add_setting(Integer(f"{FilterType.Feature.value}_limit", Scope.Global, 8))
-        self.add_setting(
-            Enum(
-                f"{FilterType.Layers.value}_priority",
-                Scope.Global,
+            cls.filter_vt_limit = QgsSettingsEntryInteger(
+                f"{FilterType.VectorTiles.value}_limit", settings_node, 8
+            )
+
+            cls.filter_feature_priority = QgsSettingsEntryEnumFlag(
+                f"{FilterType.Feature.value}_priority",
+                settings_node,
                 QgsLocatorFilter.Priority.High,
             )
-        )
-        self.add_setting(Integer(f"{FilterType.Layers.value}_limit", Scope.Global, 5))
+            cls.filter_feature_limit = QgsSettingsEntryInteger(
+                f"{FilterType.Feature.value}_limit", settings_node, 8
+            )
 
-        self.add_setting(Bool("feature_search_restrict", Scope.Global, False))
-        self.add_setting(Stringlist("feature_search_layers_list", Scope.Global, None))
+            cls.filter_layers_priority = QgsSettingsEntryEnumFlag(
+                f"{FilterType.Layers.value}_priority",
+                settings_node,
+                QgsLocatorFilter.Priority.High,
+            )
+            cls.filter_layers_limit = QgsSettingsEntryInteger(
+                f"{FilterType.Layers.value}_limit", settings_node, 5
+            )
 
-        self.add_setting(Bool("layers_include_opendataswiss", Scope.Global, True))
+        return cls.instance

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -38,7 +38,7 @@ from swiss_locator.core.filters.filter_type import FilterType
 PLUGIN_NAME = "swiss_locator_plugin"
 
 
-class Settings(object):
+class Settings:
     instance = None
 
     def __new__(cls):

--- a/swiss_locator/gui/config_dialog.py
+++ b/swiss_locator/gui/config_dialog.py
@@ -25,8 +25,12 @@ import os
 from qgis.PyQt.QtCore import Qt, pyqtSlot
 from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem, QAbstractItemView, QComboBox
 from qgis.PyQt.uic import loadUiType
-from qgis.core import QgsLocatorFilter
-from qgis.gui import QgsSettingsStringComboBoxWrapper
+from qgis.core import QgsLocatorFilter, metaEnumFromType
+from qgis.gui import (
+    QgsSettingsEditorWidgetWrapper,
+    QgsSettingsStringComboBoxWrapper,
+    QgsSettingsBoolCheckBoxWrapper,
+)
 
 from ..core.settings import Settings
 from ..core.language import get_language
@@ -39,11 +43,23 @@ DialogUi, _ = loadUiType(os.path.join(os.path.dirname(__file__), "../ui/config.u
 
 
 class ConfigDialog(QDialog, DialogUi):
+    def accept(self):
+        for wrapper in self.wrappers:
+            wrapper.setSettingFromWidget()
+
+        layers_list = []
+        for r in range(self.feature_search_layers_list.rowCount()):
+            item = self.feature_search_layers_list.item(r, 0)
+            if item.checkState() == Qt.CheckState.Checked:
+                layers_list.append(item.text())
+        self.settings.feature_search_layers_list.setValue(layers_list)
+        super().accept()
+
     def __init__(self, parent=None):
         self.settings = Settings()
         QDialog.__init__(self, parent)
-
         self.setupUi(self)
+        self.wrappers: [QgsSettingsEditorWidgetWrapper] = []
 
         self.lang.addItem(
             self.tr("use the application locale, defaults to English"), ""
@@ -51,24 +67,51 @@ class ConfigDialog(QDialog, DialogUi):
         for key, val in AVAILABLE_LANGUAGES.items():
             self.lang.addItem(key, val)
 
-        self.lang_wrapper = QgsSettingsStringComboBoxWrapper(
-            self.lang, self.settings.lang
+        self.wrappers.append(
+            QgsSettingsStringComboBoxWrapper(
+                self.lang,
+                self.settings.lang,
+                QgsSettingsStringComboBoxWrapper.Mode.Data,
+            )
         )
 
+        self.wrappers.append(
+            QgsSettingsBoolCheckBoxWrapper(
+                self.layers_include_opendataswiss,
+                self.settings.layers_include_opendataswiss,
+            )
+        )
+        self.wrappers.append(
+            QgsSettingsBoolCheckBoxWrapper(
+                self.feature_search_restrict, self.settings.feature_search_restrict
+            )
+        )
+
+        me = metaEnumFromType(QgsLocatorFilter.Priority)
         for filter_type in FilterType:
             cb = self.findChild(QComboBox, "{}_priority".format(filter_type.value))
             if cb is not None:  # Some filters might not have a config dialog
-                cb.addItem(self.tr("Highest"), QgsLocatorFilter.Priority.Highest)
-                cb.addItem(self.tr("High"), QgsLocatorFilter.Priority.High)
-                cb.addItem(self.tr("Medium"), QgsLocatorFilter.Priority.Medium)
-                cb.addItem(self.tr("Low"), QgsLocatorFilter.Priority.Low)
-                cb.addItem(self.tr("Lowest"), QgsLocatorFilter.Priority.Lowest)
+                cb.addItem(
+                    self.tr("Highest"), me.valueToKey(QgsLocatorFilter.Priority.Highest)
+                )
+                cb.addItem(
+                    self.tr("High"), me.valueToKey(QgsLocatorFilter.Priority.High)
+                )
+                cb.addItem(
+                    self.tr("Medium"), me.valueToKey(QgsLocatorFilter.Priority.Medium)
+                )
+                cb.addItem(self.tr("Low"), me.valueToKey(QgsLocatorFilter.Priority.Low))
+                cb.addItem(
+                    self.tr("Lowest"), me.valueToKey(QgsLocatorFilter.Priority.Lowest)
+                )
 
-        self.crs.addItem(
-            self.tr("Use map CRS if possible, defaults to CH1903+"), "project"
-        )
-        self.crs.addItem("CH 1903+ (EPSG:2056)", "2056")
-        self.crs.addItem("CH 1903 (EPSG:21781)", "21781")
+                self.wrappers.append(
+                    QgsSettingsStringComboBoxWrapper(
+                        cb,
+                        self.settings.filters[filter_type.value]["priority"],
+                        QgsSettingsStringComboBoxWrapper.Mode.Data,
+                    )
+                )
 
         self.search_line_edit.textChanged.connect(self.filter_rows)
         self.select_all_button.pressed.connect(self.select_all)
@@ -88,10 +131,14 @@ class ConfigDialog(QDialog, DialogUi):
             QAbstractItemView.SelectionMode.SingleSelection
         )
         r = 0
+        layers_list = self.settings.feature_search_layers_list.value()
         for layer, description in layers.items():
             item = QTableWidgetItem(layer)
             item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsUserCheckable)
-            # item.setCheckState(Qt.Unchecked)
+            checked = layer in layers_list
+            item.setCheckState(
+                Qt.CheckState.Checked if checked else Qt.CheckState.Unchecked
+            )
             self.feature_search_layers_list.setItem(r, 0, item)
             self.feature_search_layers_list.setItem(r, 1, QTableWidgetItem(description))
             r += 1
@@ -102,6 +149,12 @@ class ConfigDialog(QDialog, DialogUi):
             self.show_map_tip.setEnabled(False)
             self.show_map_tip.setToolTip(
                 self.tr("You need to install QtWebKit to use map tips.")
+            )
+        else:
+            self.wrappers.append(
+                QgsSettingsBoolCheckBoxWrapper(
+                    self.show_map_tip, self.settings.show_map_tip
+                )
             )
 
     def select_all(self, select: bool = True):

--- a/swiss_locator/map_geo_admin/layers.py
+++ b/swiss_locator/map_geo_admin/layers.py
@@ -43,8 +43,8 @@ def searchable_layers(lang: str, restrict: bool = False) -> dict:
     assert lang in AVAILABLE_LANGUAGES.values()
 
     settings = Settings()
-    restrict_enabled_by_user = settings.value("feature_search_restrict")
-    restrict_layer_list = settings.value("feature_search_layers_list")
+    restrict_enabled_by_user = settings.feature_search_restrict.value()
+    restrict_layer_list = settings.feature_search_layers_list.value()
 
     layers = {}
 

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -8,6 +8,9 @@ version=dev
 author=OPENGIS.ch
 email=info@opengis.ch
 
+supportsQt6=yes
+
+
 # Tags are comma separated with spaces allowed
 tags=swiss, suisse, schweiz, locator, geoadmin, geoportal, opendata.swiss
 

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -1,7 +1,7 @@
 
 [general]
 name=Swiss Locator
-qgisMinimumVersion=3.16
+qgisMinimumVersion=3.34
 description=A locator filter for Swiss Geoportal (geo.admin.ch) and opendata.swiss resources
 about=Search for locations, WMS layers of features in the whole Swiss Geoportal catalog as well as in opendata.swiss
 version=dev

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -1,7 +1,7 @@
 
 [general]
 name=Swiss Locator
-qgisMinimumVersion=3.34
+qgisMinimumVersion=3.40
 description=A locator filter for Swiss Geoportal (geo.admin.ch) and opendata.swiss resources
 about=Search for locations, WMS layers of features in the whole Swiss Geoportal catalog as well as in opendata.swiss
 version=dev

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -20,7 +20,7 @@
 import os
 from qgis.PyQt.QtCore import QCoreApplication, QLocale, QSettings, QTranslator
 from qgis.PyQt.QtWidgets import QWidget
-from qgis.core import Qgis, QgsApplication, QgsMessageLog, NULL
+from qgis.core import Qgis, QgsApplication, QgsMessageLog, NULL, QgsSettingsTree
 from qgis.gui import QgisInterface, QgsMessageBarItem
 
 from swiss_locator.core.filters.swiss_locator_filter_feature import (
@@ -36,11 +36,14 @@ from swiss_locator.core.filters.swiss_locator_filter_wmts import SwissLocatorFil
 from swiss_locator.core.filters.swiss_locator_filter_vector_tiles import (
     SwissLocatorFilterVectorTiles,
 )
+
 try:
     from swiss_locator.core.profiles.profile_generator import SwissProfileSource
 except ImportError:
     # Should fail only for QGIS < 3.26, where profiles weren't available
     SwissProfileSource = None
+
+from swiss_locator.core.settings import PLUGIN_NAME
 
 
 class SwissLocatorPlugin:
@@ -75,11 +78,13 @@ class SwissLocatorPlugin:
             self.locator_filters[-1].message_emitted.connect(self.show_message)
 
         if Qgis.QGIS_VERSION_INT >= 33700:
-            QgsApplication.profileSourceRegistry().registerProfileSource(self.profile_source)
+            QgsApplication.profileSourceRegistry().registerProfileSource(
+                self.profile_source
+            )
             QgsMessageLog.logMessage(
                 "Swiss profile source has been registered!",
                 "Swiss locator",
-                Qgis.MessageLevel.Info
+                Qgis.MessageLevel.Info,
             )
 
     def unload(self):
@@ -88,12 +93,16 @@ class SwissLocatorPlugin:
             self.iface.deregisterLocatorFilter(locator_filter)
 
         if Qgis.QGIS_VERSION_INT >= 33700:
-            QgsApplication.profileSourceRegistry().unregisterProfileSource(self.profile_source)
+            QgsApplication.profileSourceRegistry().unregisterProfileSource(
+                self.profile_source
+            )
             QgsMessageLog.logMessage(
                 "Swiss profile source has been unregistered!",
                 "Swiss locator",
-                Qgis.MessageLevel.Info
+                Qgis.MessageLevel.Info,
             )
+
+        QgsSettingsTree.unregisterPluginTreeNode(PLUGIN_NAME)
 
     def show_message(
         self, title: str, msg: str, level: Qgis.MessageLevel, widget: QWidget = None

--- a/swiss_locator/ui/config.ui
+++ b/swiss_locator/ui/config.ui
@@ -14,50 +14,17 @@
    <string>Swiss locator filter configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Language</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Coordinates system</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="crs"/>
-   </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="lang"/>
    </item>
-   <item row="10" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="1" column="0" colspan="3">
+    <widget class="QCheckBox" name="show_map_tip">
+     <property name="text">
+      <string>Show map tip on the map whenever possible</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
-    <spacer name="horizontalSpacer_5">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -273,7 +240,7 @@
             <property name="enabled">
              <bool>true</bool>
             </property>
-            <property name="showSearchIcon" stdset="0">
+            <property name="showSearchIcon">
              <bool>true</bool>
             </property>
             <property name="qgisRelation" stdset="0">
@@ -328,12 +295,35 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
-    <widget class="QCheckBox" name="show_map_tip">
-     <property name="text">
-      <string>Show map tip on the map whenever possible</string>
+   <item row="9" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Language</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/swiss_locator/ui/config.ui
+++ b/swiss_locator/ui/config.ui
@@ -27,7 +27,7 @@
    <item row="3" column="0" colspan="3">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="locations">
       <attribute name="title">
@@ -94,8 +94,18 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="1" rowspan="2">
-        <widget class="QComboBox" name="wmts_priority"/>
+       <item row="3" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="1" column="0" rowspan="2">
         <widget class="QLabel" name="label_10">
@@ -107,15 +117,18 @@
        <item row="2" column="1">
         <widget class="QSpinBox" name="wmts_limit"/>
        </item>
-       <item row="3" column="0">
-        <spacer name="verticalSpacer">
+       <item row="0" column="1" rowspan="2">
+        <widget class="QComboBox" name="wmts_priority"/>
+       </item>
+       <item row="0" column="2">
+        <spacer name="horizontalSpacer_6">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
-           <height>40</height>
+           <width>40</width>
+           <height>20</height>
           </size>
          </property>
         </spacer>


### PR DESCRIPTION
This makes the plugin compatible with Qt6 builds.

QGIS minimum version is raised to 3.34, the config dialogs is shown only for 3.40+.

Another approach would be to set the new minimum version to 3.40 (so we would leave the old version for 3.34-3.38), no strong opinion here.