### PR TITLE
[wmts] Make sure WMTS layer with several time values can be displayed in the Temporal Controller

### DIFF
--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -136,6 +136,9 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
             for dim in layer.findall(".//wmts:Dimension", namespaces):
                 identifier = dim.find("./ows:Identifier", namespaces).text
                 default = dim.find("./wmts:Default", namespaces).text
+                dimension_values = dim.findall(".//wmts:Value", namespaces)
+                if len(dimension_values) > 1 and identifier.lower() == "time":
+                    continue  # Let the temporal controller take care of it
                 dimensions[identifier] = default
             dimensions = "&".join([f"{k}={v}" for (k, v) in dimensions.items()])
             dimensions = urllib.parse.quote(dimensions)

--- a/swiss_locator/core/filters/swiss_locator_filter_wmts.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_wmts.py
@@ -132,12 +132,14 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
             layer_title = layer.find(".//ows:Title", namespaces).text
             layer_abstract = layer.find(".//ows:Abstract", namespaces).text
             layer_identifier = layer.find(".//ows:Identifier", namespaces).text
+            temporal_wmts = False
             dimensions = dict()
             for dim in layer.findall(".//wmts:Dimension", namespaces):
                 identifier = dim.find("./ows:Identifier", namespaces).text
                 default = dim.find("./wmts:Default", namespaces).text
                 dimension_values = dim.findall(".//wmts:Value", namespaces)
                 if len(dimension_values) > 1 and identifier.lower() == "time":
+                    temporal_wmts = True
                     continue  # Let the temporal controller take care of it
                 dimensions[identifier] = default
             dimensions = "&".join([f"{k}={v}" for (k, v) in dimensions.items()])
@@ -161,7 +163,7 @@ class SwissLocatorFilterWMTS(SwissLocatorFilter):
 
                 result = QgsLocatorResult()
                 result.filter = self
-                result.icon = QgsApplication.getThemeIcon("/mActionAddWmsLayer.svg")
+                result.icon = QgsApplication.getThemeIcon("/mIconTemporalRaster.svg") if temporal_wmts else QgsApplication.getThemeIcon("/mActionAddWmsLayer.svg")
 
                 result.displayString = layer_title
                 result.description = layer_abstract


### PR DESCRIPTION
Avoid setting the temporal extent (e.g., `tileDimensions=Time=current`) if the layer has more than one value for the dimension identifier 'Time'. This allows the temporal controller to take care of the layer's temporal display.

Note: When there is a single value for the Time dimension, we still need to set it in the `tileDimensions` parameter (we don't alter the behavior here, which is correct).

-----

Somehow related, we now show the temporal raster icon for WMTS layers that will be handled by the Temporal Controller, so that it is possible to know about the temporal capability even before loading a layer.

-----

Fix #109 