### PR TITLE
Adapt Elevation Profile to new API (expected for QGIS 4.0)

### DIFF
--- a/swiss_locator/core/profiles/profile_generator.py
+++ b/swiss_locator/core/profiles/profile_generator.py
@@ -112,11 +112,16 @@ class SwissProfileGenerator(QgsAbstractProfileGenerator):
             self.__results.ellipsoidal_distance_to_height[d] = z
             self.__results.ellipsoidal_cross_section_geometries.append(QgsGeometry(QgsPoint(d, z)))
 
-            if d != 0:
-                # QGIS elevation profile won't calculate distances
-                # using 3d, so let's stick to 2d to avoid getting
-                # displaced markers or lines in the profile canvas
-                cartesian_d += QgsGeometryUtils.distance2D(point_z, self.__results.raw_points[-1])
+            try:
+                if d != 0:
+                    # QGIS elevation profile won't calculate distances
+                    # using 3d, so let's stick to 2d to avoid getting
+                    # displaced markers or lines in the profile canvas
+                    cartesian_d += QgsGeometryUtils.distance2D(point_z, self.__results.raw_points[-1])
+            except IndexError as e:
+                QgsMessageLog.logMessage(f"\nError in SwissLocator Elevation Profile. Details: {e}",
+                                         "Swiss locator", Qgis.MessageLevel.Critical)
+                return False
 
             self.__results.raw_points.append(point_z)
             self.__results.cartesian_distance_to_height[cartesian_d] = z

--- a/swiss_locator/core/profiles/profile_generator.py
+++ b/swiss_locator/core/profiles/profile_generator.py
@@ -140,5 +140,11 @@ class SwissProfileSource(QgsAbstractProfileSource):
     def __init__(self):
         QgsAbstractProfileSource.__init__(self)
 
+    def profileSourceId(self):
+        return "swiss-profile"
+
+    def profileSourceName(self):
+        return "Swiss Profile"
+
     def createProfileGenerator(self, request):
         return SwissProfileGenerator(request)

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -122,10 +122,17 @@ class SwissLocatorPlugin:
                         self.open_stac_filter_widget)
             self.iface.deregisterLocatorFilter(locator_filter)
 
+
         if Qgis.QGIS_VERSION_INT >= 33700:
-            QgsApplication.profileSourceRegistry().unregisterProfileSource(
-                self.profile_source
-            )
+            if Qgis.QGIS_VERSION_INT >= 39900:  # Change to 40000 from QGIS 4.0 onwards
+                QgsApplication.profileSourceRegistry().unregisterProfileSource(
+                    "swiss-profile"
+                )
+            else:  # Legacy, remove for QGIS v4.0
+                QgsApplication.profileSourceRegistry().unregisterProfileSource(
+                    self.profile_source
+                )
+
             QgsMessageLog.logMessage(
                     "Swiss profile source has been unregistered!",
                     "Swiss locator",

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -122,7 +122,6 @@ class SwissLocatorPlugin:
                         self.open_stac_filter_widget)
             self.iface.deregisterLocatorFilter(locator_filter)
 
-
         if Qgis.QGIS_VERSION_INT >= 33700:
             if Qgis.QGIS_VERSION_INT >= 39900:  # Change to 40000 from QGIS 4.0 onwards
                 QgsApplication.profileSourceRegistry().unregisterProfileSource(


### PR DESCRIPTION
That is:

 + return id and name from the source, and
 + unregister by source id instead of by source object.

--------

Note: 
This is the expected behavior for prior and future versions of SwissLocator and QGIS, regarding Elevation Profile functionality. All 4 scenarios should allow users to display an Elevation profile.

|                       | **QGIS < 4.0**                           | **QGIS >= 4.0**                                                  |
|-----------------------|--------------------------------------|--------------------------------------------------------------|
| **SwissLocator < This PR**  | No entry in the Elevation layer tree | Entry in Elevation layer tree  with an UUID as name          |
| **SwissLocator >= This PR** | No entry in the Elevation layer tree | Entry in Elevation layer tree  with the name "Swiss Profile" |

-------

To see the new Elevation Profile features in action, you should have QGIS 4.0 (_or QGIS master 3.99,  ⚠️ build after 25th September 2025_). (See [QGIS PR](https://github.com/qgis/QGIS/pull/62819) for details)


<img width="570" height="311" alt="image" src="https://github.com/user-attachments/assets/08dd6475-9170-44ee-9777-7756aa7c37a6" />
