### PR TITLE
Plugin language isn't derived from locale

### DIFF
--- a/swiss_locator/core/language.py
+++ b/swiss_locator/core/language.py
@@ -41,7 +41,7 @@ def get_language() -> str:
     if not lang:
         locale = str(QSettings().value("locale/userLocale")).replace(str(NULL), "en_CH")
         locale_lang = QLocale.languageToString(QLocale(locale).language())
-        if locale_lang in AVAILABLE_LANGUAGES:
+        if locale_lang in AVAILABLE_LANGUAGES.keys():
             lang = AVAILABLE_LANGUAGES[locale_lang]
     if lang not in AVAILABLE_LANGUAGES.values():
         lang = "en"

--- a/swiss_locator/core/language.py
+++ b/swiss_locator/core/language.py
@@ -43,7 +43,7 @@ def get_language() -> str:
         locale_lang = QLocale.languageToString(QLocale(locale).language())
         if locale_lang in AVAILABLE_LANGUAGES:
             lang = AVAILABLE_LANGUAGES[locale_lang]
-    if lang not in AVAILABLE_LANGUAGES:
+    if lang not in AVAILABLE_LANGUAGES.values():
         lang = "en"
 
     return lang

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -46,8 +46,8 @@ class Settings:
             cls.instance = super(Settings, cls).__new__(cls)
 
             settings_node = QgsSettingsTree.createPluginTreeNode(pluginName=PLUGIN_NAME)
-
-            cls.lang = QgsSettingsEntryString("lang", settings_node, "lang")
+            
+            cls.lang = QgsSettingsEntryString("lang", settings_node, "")
             cls.show_map_tip = QgsSettingsEntryBool(
                 "show_map_tip", settings_node, False
             )

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -56,7 +56,7 @@ class SwissLocatorPlugin:
         )
         locale_path = os.path.join(os.path.dirname(__file__), "i18n")
         self.translator = QTranslator()
-        self.translator.load(qgis_locale, "qgis-swiss-locator", "_", locale_path)
+        self.translator.load(qgis_locale, "swiss_locator", "_", locale_path)
         QCoreApplication.installTranslator(self.translator)
 
         self.locator_filters = []


### PR DESCRIPTION
Solves #112

The plugin currently always defaults to english. 
The language setting needs to be initialized to an empty string, so it can then be read from the locale. 