### PR TITLE
Add swisstopo STAC catalog as new locator filter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
      language_version: python3
 
  - repo: https://github.com/PyCQA/flake8
-   rev: 3.9.2
+   rev: 5.0.4
    hooks:
    - id: flake8
      args: ['--ignore=E203,E402,E501,W503']

--- a/swiss_locator/core/filters/filter_type.py
+++ b/swiss_locator/core/filters/filter_type.py
@@ -7,3 +7,4 @@ class FilterType(Enum):
     Feature = "featuresearch"  # this is used in map.geo.admin as the search type
     WMTS = "wmts"
     VectorTiles = "vectortiles"
+    STAC = "stac"

--- a/swiss_locator/core/filters/map_geo_admin_stac.py
+++ b/swiss_locator/core/filters/map_geo_admin_stac.py
@@ -1,0 +1,83 @@
+import json
+import urllib.request
+
+from qgis._core import QgsStacCollection
+
+from swiss_locator.core.stac.stac_client import StacClient
+
+BASE_URL = "https://data.geo.admin.ch/api/stac/v1"
+
+
+def fetchStacCollections(lang):
+    # TODO: Make both calls async
+    
+    stac_client = StacClient(BASE_URL)
+    collections = stac_client.fetchCollections()
+    
+    data_geo_admin_metadata = getGeoAdminMetadata(lang)
+    
+    stacCollections = {}
+    
+    for collection in collections:
+        
+        if collection.id() in data_geo_admin_metadata:
+            metadata = data_geo_admin_metadata[collection.id()]
+            
+            collection.setTitle(metadata.get('title'))
+            collection.setDescription(metadata.get('description'))
+        
+        stacCollections[collection.id()] = collection
+    
+    return stacCollections
+
+
+def getGeoAdminMetadata(lang):
+    """ Calls geoadmin API and retrieves translated titles and
+    descriptions."""
+    url = f"https://api3.geo.admin.ch/rest/services/api/MapServer?lang={lang}"
+    contents = (
+        urllib.request.urlopen(url)
+        .read()
+        .decode("utf-8")
+    )
+    data = json.loads(contents)
+    
+    metadata = {}
+    
+    for layer in data['layers']:
+        
+        title = ''
+        description = ''
+        if 'layerBodId' not in layer:
+            continue
+        collectionId = layer['layerBodId']
+        if 'fullName' in layer:
+            title = layer['fullName']
+        if 'attributes' in layer and 'fullTextSearch' in layer['attributes']:
+            description = layer['attributes']['fullTextSearch']
+        
+        metadata[collectionId] = {
+            'title': title,
+            'description': description
+        }
+    return metadata
+
+
+def collectionsToSearchStrings(collections: dict[str, QgsStacCollection]):
+    collectionIds = []
+    collectionSearchStrings = []
+    for (collId, collection) in collections.items():
+        collectionIds.append(collId)
+        parsedCollectionId = collId.lower().replace('.', ' ')
+        parsedCollectionTitle = collection.title().lower()
+        collectionSearchStrings.append(
+                f"{parsedCollectionId} {parsedCollectionTitle}")
+    return collectionSearchStrings, collectionIds
+
+
+def map_geo_admin_stac_items_url(id: str, limit: int):
+    base_url = f"https://data.geo.admin.ch/api/stac/v1/collections/{id}/items"
+    base_params = {
+        "limit": str(limit)
+    }
+    return base_url, base_params

--- a/swiss_locator/core/filters/map_geo_admin_stac.py
+++ b/swiss_locator/core/filters/map_geo_admin_stac.py
@@ -3,14 +3,14 @@ import urllib.request
 
 from qgis.core import QgsStacCollection
 
-from swiss_locator.core.stac.stac_client import StacClient
+from swiss_locator.core.stac.stac_client import STACClient
 
 BASE_URL = "https://data.geo.admin.ch/api/stac/v1"
 METADATA_URL = "https://api3.geo.admin.ch/rest/services/api/MapServer"
 
 
 def fetch_stac_collections_with_metadata(_task, lang):
-    stac_client = StacClient(BASE_URL)
+    stac_client = STACClient(BASE_URL)
     collections = stac_client.fetchCollections()
     
     data_geo_admin_metadata = fetch_geo_admin_metadata(lang)

--- a/swiss_locator/core/filters/map_geo_admin_stac.py
+++ b/swiss_locator/core/filters/map_geo_admin_stac.py
@@ -68,12 +68,8 @@ def collections_to_searchable_strings(
     collection_search_strings = []
     for (coll_id, collection) in collections.items():
         collection_ids.append(coll_id)
-        # Clean up strings by replacing any non-alphanumeric characters with spaces
-        parsed_collection_id = re.sub(r'[.,-–_/\\()]', ' ', coll_id.lower())
-        parsed_collection_title = re.sub(r'[.,-–_/\\()]', ' ',
-                                         collection.title().lower())
         collection_search_strings.append(
-                " ".join([parsed_collection_id, parsed_collection_title]))
+            (" ".join([collection.title(), coll_id])).lower())
     return collection_search_strings, collection_ids
 
 

--- a/swiss_locator/core/filters/map_geo_admin_stac.py
+++ b/swiss_locator/core/filters/map_geo_admin_stac.py
@@ -1,15 +1,15 @@
 import json
-import re
 import urllib.request
 
-from qgis._core import QgsStacCollection
+from qgis.core import QgsStacCollection
 
 from swiss_locator.core.stac.stac_client import StacClient
 
 BASE_URL = "https://data.geo.admin.ch/api/stac/v1"
+METADATA_URL = "https://api3.geo.admin.ch/rest/services/api/MapServer"
 
 
-def fetch_stac_collections(_task, lang):
+def fetch_stac_collections_with_metadata(_task, lang):
     stac_client = StacClient(BASE_URL)
     collections = stac_client.fetchCollections()
     
@@ -33,7 +33,7 @@ def fetch_stac_collections(_task, lang):
 def fetch_geo_admin_metadata(lang):
     """ Calls geoadmin API and retrieves translated titles and
     descriptions."""
-    url = f"https://api3.geo.admin.ch/rest/services/api/MapServer?lang={lang}"
+    url = f"{METADATA_URL}?lang={lang}"
     contents = (
         urllib.request.urlopen(url)
         .read()
@@ -74,8 +74,8 @@ def collections_to_searchable_strings(
 
 
 def map_geo_admin_stac_items_url(collection_id: str, limit: int):
-    base_url = f"{BASE_URL}/collections/{collection_id}/items"
+    url = f"{BASE_URL}/collections/{collection_id}/items"
     base_params = {
         "limit": str(limit)
     }
-    return base_url, base_params
+    return url, base_params

--- a/swiss_locator/core/filters/swiss_locator_filter.py
+++ b/swiss_locator/core/filters/swiss_locator_filter.py
@@ -516,8 +516,10 @@ class SwissLocatorFilter(QgsLocatorFilter):
                     root.insertLayer(-1, ch_layer)
         
         elif type(swiss_result) == STACResult:
-            if swiss_result.is_downloadable_file:
-                self.fetch_asset(swiss_result)
+            if swiss_result.is_streamed:
+                self.add_asset_to_qgis(swiss_result)
+            elif swiss_result.is_downloadable:
+                self.download_asset(swiss_result)
             else:
                 # TODO: Open filter dialog
                 pass

--- a/swiss_locator/core/filters/swiss_locator_filter_feature.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_feature.py
@@ -20,7 +20,6 @@
 import json
 
 from qgis.PyQt.QtGui import QIcon
-
 from qgis.core import (
     Qgis,
     QgsFeedback,
@@ -29,12 +28,12 @@ from qgis.core import (
 )
 from qgis.gui import QgisInterface
 
+from swiss_locator.core.filters.filter_type import FilterType
+from swiss_locator.core.filters.map_geo_admin import map_geo_admin_url
 from swiss_locator.core.filters.swiss_locator_filter import (
     SwissLocatorFilter,
 )
-from swiss_locator.core.filters.filter_type import FilterType
 from swiss_locator.core.results import FeatureResult
-from swiss_locator.core.filters.map_geo_admin import map_geo_admin_url
 from swiss_locator.map_geo_admin.layers import searchable_layers
 
 
@@ -58,7 +57,7 @@ class SwissLocatorFilterFeature(SwissLocatorFilter):
         # otherwise URL is too long
         requests = []
         try:
-            limit = self.settings.filter_feature_limit.value()
+            limit = self.settings.filters[self.type.value]["limit"].value()
             layers = list(self.searchable_layers.keys())
             assert len(layers) > 0
             step = 20

--- a/swiss_locator/core/filters/swiss_locator_filter_stac.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_stac.py
@@ -1,0 +1,188 @@
+import json
+
+from PyQt5.QtCore import QUrl
+from PyQt5.QtNetwork import QNetworkRequest
+from qgis.core import (
+    QgsApplication, QgsFeedback, QgsLocatorResult,
+    QgsStacCollection
+)
+from qgis.gui import QgisInterface
+
+from swiss_locator.core.filters.filter_type import FilterType
+from swiss_locator.core.filters.map_geo_admin_stac import (
+    collectionsToSearchStrings,
+    fetchStacCollections,
+    map_geo_admin_stac_items_url
+)
+from swiss_locator.core.filters.swiss_locator_filter import SwissLocatorFilter
+from swiss_locator.core.results import STACResult
+from swiss_locator.utils.utils import url_with_param
+
+FILE_TYPE_ICONS = {
+    'default': "/mActionAddLayer.svg",
+    'zip': "/mIconZip.svg",
+    'tiff': "/mActionAddRasterLayer.svg",
+    'geotiff': "/mActionAddRasterLayer.svg",
+    "ascii": "/mActionAddRasterLayer.svg",
+    "xyz": "/mActionAddRasterLayer.svg",
+    "grid": "/mActionAddRasterLayer.svg",
+    'shapefile': "/mActionAddBasicShape.svg",
+    'csv': "/mActionAddDelimitedTextLayer.svg",
+    "jpeg": "/mActionAddImage.svg",
+    "interlis": "/mActionAddLayer.svg",
+    "filegdb": "/mActionAddOracleLayer.svg",
+    "streamed": "/mActionAddRasterLayer.svg",
+    "geopackage": "/mActionAddGeoPackageLayer.svg",
+    "json": "/mActionAddOgrLayer.svg",
+    "geojson": "/mActionAddOgrLayer.svg",
+    "pdf": "/mActionTextInsideRect.svg",
+    "xml": "/mActionAddHtml.svg",
+    "netcdf": "/mActionAddLayer.svg",
+    "kml": "mActionAddHtml.svg",
+    "kmz": "/mIconZip.svg",
+    "filter": "/mIndicatorFilter.svg",
+        
+    }
+
+
+class SwissLocatorFilterSTAC(SwissLocatorFilter):
+    HEADERS = {b"User-Agent": b"Mozilla/5.0 QGIS Swiss Geoportal Stac Filter"}
+    
+    def __init__(self, iface: QgisInterface = None, crs: str = None,
+                 data=None):
+        super().__init__(FilterType.STAC, iface, crs)
+        self.minimum_search_length = 4
+        self.maximum_assets_per_collection = 3
+        
+        if data:
+            self.collections = data[0]
+            self.collectionSearchStrings = data[1]
+            self.collectionIds = data[2]
+            return
+        # Since the swisstopo STAC catalog does not provide a useful
+        # search API to query collections, the collections are fetched
+        # initially and titles are placed in a searchable list
+        # TODO: make calls async, non-blocking
+        self.collections: dict[str, QgsStacCollection] = fetchStacCollections(
+                self.lang)
+        self.collectionSearchStrings, self.collectionIds = collectionsToSearchStrings(
+                self.collections)
+    
+    def clone(self):
+        # TODO: What to do when language changes?
+        return SwissLocatorFilterSTAC(crs=self.crs, data=(self.collections,
+            self.collectionSearchStrings,
+            self.collectionIds))
+    
+    def displayName(self):
+        return self.tr("Swiss Geoportal STAC file download")
+    
+    def prefix(self):
+        return "chstac"
+    
+    def perform_local_search(self, search: str):
+        # TODO: ranks, order results!
+        indexes = [i for (i, s) in enumerate(self.collectionSearchStrings) if
+            search.lower() in s]
+        return [self.collectionIds[idx] for idx in indexes]
+    
+    def perform_fetch_results(self, search: str, feedback: QgsFeedback):
+        # Remove the opendata swiss link, keep the map_geo_admin one
+        limit = self.settings.filters[self.type.value]["limit"].value()
+        
+        matchingCollections = self.perform_local_search(search)[:limit]
+        requests = []
+        # For each collection, request a handful of items so we get a sense of the collection
+        for collectionId in matchingCollections:
+            url, params = map_geo_admin_stac_items_url(collectionId, 5)
+            requests.append(
+                    self.request_for_url(url, params, self.HEADERS))
+        
+        self.fetch_requests(requests, feedback, slot=self.handle_content,
+                            data=matchingCollections)
+    
+    def handle_content(self, content, feedback: QgsFeedback, data):
+        response = json.loads(content)
+        matchingCollections = data  # TODO: This should contain the order or result ranks
+        
+        if len(response.get("features", [])) == 0:
+            return
+        
+        firstItem = response["features"][0]
+        collection = self.collections[firstItem["collection"]]
+        stacResults = []
+        
+        # TODO: What is the necessary check to know if we want to show assets or not
+        if len(response["features"]) == 1:
+            # This collection contains only one item, we analyse it's assets
+            for (assetId, asset) in firstItem["assets"].items():
+                assetResult = STACResult(
+                        collection.id(),
+                        collection.title(),
+                        assetId,
+                        asset.get("description"),
+                        asset.get("type"),
+                        asset.get("href"),
+                        )
+                stacResults.append(assetResult)
+        else:
+            # Save the collection as a locator result, no use in list many assets
+            collectionResult = STACResult(collection.id(), collection.title(),
+                                          '', collection.description(),
+                                          '', '')
+            stacResults.append(collectionResult)
+        
+        # TODO: Add specific logic to decide if this result should list assets or only link to the filter ui
+        for idx, stacResult in enumerate(stacResults):
+            
+            if stacResult.is_downloadable_file:
+                # If assets can be downloaded directly, add them to the results
+                self.createLocatorResult(stacResult.collection_name,
+                                         stacResult.asset_id,
+                                         stacResult.media_type,
+                                         stacResult.as_definition(),
+                                         stacResult.simple_file_type)
+                if idx >= self.maximum_assets_per_collection - 1:
+                    break
+            else:
+                # If there are too many assets, only list the collection and
+                # show an option to open up the filter dialog
+                self.createLocatorResult(stacResult.collection_name,
+                                         f'[click] to filter individual files for {stacResult.collection_name}...',
+                                         '',
+                                         stacResult.as_definition(),
+                                         'filter')
+    
+    def createLocatorResult(self, group, title, description, userData, icon):
+        result = QgsLocatorResult()
+        result.filter = self
+        result.group = group
+        result.displayString = title
+        result.description = description
+        result.userData = userData
+        result.icon = QgsApplication.getThemeIcon(
+                self.getMatchingQgisIcon(icon))
+        self.result_found = True
+        self.resultFetched.emit(result)
+    
+    @staticmethod
+    def getMatchingQgisIcon(file_type):
+        parts = file_type.replace('.', ' ').replace('+', ' ').split()
+        
+        for part in parts:
+            if FILE_TYPE_ICONS.get(part):
+                return FILE_TYPE_ICONS.get(part)
+        
+        return FILE_TYPE_ICONS.get('default')
+    
+    def fetch_asset(self, asset: STACResult):
+        # Try to get more info
+        url = asset.href
+        url = url_with_param(url, {})
+        request = QNetworkRequest(QUrl(url))
+        # TODO: Download file with QgsFileDownloader, using self.event_loop
+        self.fetch_request(request, QgsFeedback(), self.parse_asset_response)
+    
+    def parse_asset_response(self):
+        # TODO: Download file
+        pass

--- a/swiss_locator/core/filters/swiss_locator_filter_stac.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_stac.py
@@ -20,7 +20,7 @@ from qgis.gui import QgisInterface
 from swiss_locator.core.filters.filter_type import FilterType
 from swiss_locator.core.filters.map_geo_admin_stac import (
     collections_to_searchable_strings,
-    fetch_stac_collections,
+    fetch_stac_collections_with_metadata,
     map_geo_admin_stac_items_url
 )
 from swiss_locator.core.filters.swiss_locator_filter import (
@@ -84,7 +84,7 @@ class SwissLocatorFilterSTAC(SwissLocatorFilter):
     def fetch_stac_collections(self):
         self.stac_fetch_task = QgsTask.fromFunction(
                 self.tr('Fetch Swisstopo STAC collections'),
-                fetch_stac_collections,
+                fetch_stac_collections_with_metadata,
                 self.lang,
                 on_finished=self.receive_stac_collections)
         
@@ -111,7 +111,7 @@ class SwissLocatorFilterSTAC(SwissLocatorFilter):
         return self.tr("Swiss Geoportal STAC file download")
     
     def prefix(self):
-        return "chc"
+        return "chd"
     
     def perform_local_search(self, search_term: str):
         """ Perform search on a list of strings containing the STAC collection
@@ -201,8 +201,7 @@ class SwissLocatorFilterSTAC(SwissLocatorFilter):
                                 '', '')
             
             self.create_locator_result(result.collection_name,
-                                       self.tr(
-                                               '[click] to open filter dialog'),
+                                       self.tr('open filter dialog'),
                                        '',
                                        result.as_definition(),
                                        'filter')

--- a/swiss_locator/core/filters/swiss_locator_filter_stac.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_stac.py
@@ -1,22 +1,31 @@
 import json
+import os
+from copy import deepcopy
 
-from PyQt5.QtCore import QUrl
-from PyQt5.QtNetwork import QNetworkRequest
+from qgis.PyQt.QtCore import QEventLoop
 from qgis.core import (
-    QgsApplication, QgsFeedback, QgsLocatorResult,
+    QgsTask,
+    QgsProject,
+    QgsRasterLayer,
+    QgsVectorLayer,
+    Qgis,
+    QgsFileDownloader,
+    QgsApplication,
+    QgsFeedback,
+    QgsLocatorResult,
     QgsStacCollection
 )
 from qgis.gui import QgisInterface
 
 from swiss_locator.core.filters.filter_type import FilterType
 from swiss_locator.core.filters.map_geo_admin_stac import (
-    collectionsToSearchStrings,
-    fetchStacCollections,
+    collections_to_searchable_strings,
+    fetch_stac_collections,
     map_geo_admin_stac_items_url
 )
 from swiss_locator.core.filters.swiss_locator_filter import SwissLocatorFilter
 from swiss_locator.core.results import STACResult
-from swiss_locator.utils.utils import url_with_param
+from swiss_locator.utils.utils import url_with_param, get_save_location
 
 FILE_TYPE_ICONS = {
     'default': "/mActionAddLayer.svg",
@@ -41,133 +50,175 @@ FILE_TYPE_ICONS = {
     "kml": "mActionAddHtml.svg",
     "kmz": "/mIconZip.svg",
     "filter": "/mIndicatorFilter.svg",
-        
-    }
+}
 
 
 class SwissLocatorFilterSTAC(SwissLocatorFilter):
+    """
+    Handles filtering and downloading files from the Swiss Geoportal
+    STAC data catalog.
+    Since the catalog does not provide a search endpoint to query collection
+    names or titles, the search functionality is implemented by initially
+    fetching all collections and storing titles and ids in a searchable list.
+    """
     HEADERS = {b"User-Agent": b"Mozilla/5.0 QGIS Swiss Geoportal Stac Filter"}
     
     def __init__(self, iface: QgisInterface = None, crs: str = None,
                  data=None):
         super().__init__(FilterType.STAC, iface, crs)
-        self.minimum_search_length = 4
-        self.maximum_assets_per_collection = 3
         
-        if data:
-            self.collections = data[0]
-            self.collectionSearchStrings = data[1]
-            self.collectionIds = data[2]
+        self.stac_fetch_task: QgsTask | None = None
+        self.available_collections: dict[str, QgsStacCollection] = {}
+        self.search_strings = []
+        self.collection_ids = []
+        
+        if not data:
+            self.fetch_stac_collections()
+        else:
+            self.available_collections = data[0]
+            self.search_strings = data[1]
+            self.collection_ids = data[2]
+    
+    def fetch_stac_collections(self):
+        self.stac_fetch_task = QgsTask.fromFunction(
+                self.tr('Fetch Swisstopo STAC collections'),
+                fetch_stac_collections,
+                self.lang,
+                on_finished=self.receive_stac_collections)
+        
+        QgsApplication.taskManager().addTask(self.stac_fetch_task)
+    
+    def receive_stac_collections(self, exception=None,
+                                 stac_collections: dict[
+                                     str, QgsStacCollection] = None):
+        if exception:
+            self.info(str(exception), Qgis.MessageLevel.Critical)
             return
-        # Since the swisstopo STAC catalog does not provide a useful
-        # search API to query collections, the collections are fetched
-        # initially and titles are placed in a searchable list
-        # TODO: make calls async, non-blocking
-        self.collections: dict[str, QgsStacCollection] = fetchStacCollections(
-                self.lang)
-        self.collectionSearchStrings, self.collectionIds = collectionsToSearchStrings(
-                self.collections)
+        self.available_collections = stac_collections
+        self.search_strings, self.collection_ids = collections_to_searchable_strings(
+                self.available_collections)
     
     def clone(self):
-        # TODO: What to do when language changes?
-        return SwissLocatorFilterSTAC(crs=self.crs, data=(self.collections,
-            self.collectionSearchStrings,
-            self.collectionIds))
+        return SwissLocatorFilterSTAC(crs=self.crs,
+                                      data=(
+                                          self.available_collections,
+                                          self.search_strings,
+                                          self.collection_ids))
     
     def displayName(self):
         return self.tr("Swiss Geoportal STAC file download")
     
     def prefix(self):
-        return "chstac"
+        return "chc"
     
-    def perform_local_search(self, search: str):
-        # TODO: ranks, order results!
-        indexes = [i for (i, s) in enumerate(self.collectionSearchStrings) if
-            search.lower() in s]
-        return [self.collectionIds[idx] for idx in indexes]
+    def perform_local_search(self, search_term: str):
+        """ Perform search on a list of strings containing the STAC collection
+        id and title, and return a sorted list of corresponding collection IDs
+         for the found matches. Results are ordered by the match positions.
+        """
+        search_term = search_term.lower()
+        matches = [(i, s.find(search_term)) for (i, s) in
+            enumerate(self.search_strings)]
+        valid_matches = [(i, pos) for (i, pos) in matches if pos >= 0]
+        sorted_matches = sorted(valid_matches, key=lambda x: x[1])
+        return [self.collection_ids[idx] for idx, _ in sorted_matches]
     
     def perform_fetch_results(self, search: str, feedback: QgsFeedback):
-        # Remove the opendata swiss link, keep the map_geo_admin one
         limit = self.settings.filters[self.type.value]["limit"].value()
+        matching_collections = self.perform_local_search(search)[:limit]
         
-        matchingCollections = self.perform_local_search(search)[:limit]
+        # For each collection, request a few items to decide whether assets can
+        # be downloaded directly from the locator or a filter dialog is necessary
         requests = []
-        # For each collection, request a handful of items so we get a sense of the collection
-        for collectionId in matchingCollections:
-            url, params = map_geo_admin_stac_items_url(collectionId, 5)
+        for collection_id in matching_collections:
+            url, params = map_geo_admin_stac_items_url(collection_id, 5)
             requests.append(
                     self.request_for_url(url, params, self.HEADERS))
         
         self.fetch_requests(requests, feedback, slot=self.handle_content,
-                            data=matchingCollections)
+                            data=matching_collections)
     
     def handle_content(self, content, feedback: QgsFeedback, data):
         response = json.loads(content)
-        matchingCollections = data  # TODO: This should contain the order or result ranks
         
         if len(response.get("features", [])) == 0:
             return
         
-        firstItem = response["features"][0]
-        collection = self.collections[firstItem["collection"]]
-        stacResults = []
+        try:
+            stac_collection = self.available_collections[
+                response["features"][0]["collection"]]
+        except KeyError:
+            return
         
-        # TODO: What is the necessary check to know if we want to show assets or not
-        if len(response["features"]) == 1:
-            # This collection contains only one item, we analyse it's assets
-            for (assetId, asset) in firstItem["assets"].items():
-                assetResult = STACResult(
-                        collection.id(),
-                        collection.title(),
-                        assetId,
-                        asset.get("description"),
-                        asset.get("type"),
-                        asset.get("href"),
-                        )
-                stacResults.append(assetResult)
-        else:
-            # Save the collection as a locator result, no use in list many assets
-            collectionResult = STACResult(collection.id(), collection.title(),
-                                          '', collection.description(),
-                                          '', '')
-            stacResults.append(collectionResult)
+        max_files_per_collection = 5
+        file_count = sum([len(item["assets"].values()) for item in
+                             response["features"]])
         
-        # TODO: Add specific logic to decide if this result should list assets or only link to the filter ui
-        for idx, stacResult in enumerate(stacResults):
+        if file_count <= max_files_per_collection:
+            results = []
+            # Analyse response and create stac result objects
+            for item in response["features"]:
+                for (asset_id, asset) in item["assets"].items():
+                    asset_result = STACResult(
+                            stac_collection.id(),
+                            stac_collection.title(),
+                            asset_id,
+                            asset.get("description"),
+                            asset.get("type"),
+                            asset.get("href"),
+                    )
+                    results.append(asset_result)
+                    if asset_result.is_streamable:
+                        # Create a second, streamable asset object
+                        asset_as_stream = deepcopy(asset_result)
+                        asset_as_stream.asset_id += f" ({self.tr('streamed')})"
+                        asset_as_stream.path = f"{STACResult.STREAMED_SOURCE_PREFIX}{asset.get("href")}"
+                        results.append(asset_as_stream)
             
-            if stacResult.is_downloadable_file:
-                # If assets can be downloaded directly, add them to the results
-                self.createLocatorResult(stacResult.collection_name,
-                                         stacResult.asset_id,
-                                         stacResult.media_type,
-                                         stacResult.as_definition(),
-                                         stacResult.simple_file_type)
-                if idx >= self.maximum_assets_per_collection - 1:
-                    break
-            else:
-                # If there are too many assets, only list the collection and
-                # show an option to open up the filter dialog
-                self.createLocatorResult(stacResult.collection_name,
-                                         f'[click] to filter individual files for {stacResult.collection_name}...',
-                                         '',
-                                         stacResult.as_definition(),
-                                         'filter')
+            # Create locator entries
+            for stac_result in results:
+                if stac_result.is_downloadable:
+                    self.create_locator_result(stac_result.collection_name,
+                                               stac_result.asset_id,
+                                               stac_result.simple_file_type,
+                                               stac_result.as_definition(),
+                                               stac_result.simple_file_type)
+        
+        else:
+            # If the collection has too many items/assets, only the collection
+            #  itself is listed in the locator and further filtering is done
+            #  in a filter dialog
+            result = STACResult(stac_collection.id(),
+                                stac_collection.title(),
+                                '', stac_collection.description(),
+                                '', '')
+            
+            self.create_locator_result(result.collection_name,
+                                       self.tr(
+                                               '[click] to open filter dialog'),
+                                       '',
+                                       result.as_definition(),
+                                       'filter')
     
-    def createLocatorResult(self, group, title, description, userData, icon):
+    def create_locator_result(self, group, title, description, user_data,
+                              icon):
         result = QgsLocatorResult()
         result.filter = self
         result.group = group
         result.displayString = title
         result.description = description
-        result.userData = userData
+        result.userData = user_data
         result.icon = QgsApplication.getThemeIcon(
-                self.getMatchingQgisIcon(icon))
+                self.get_matching_result_icon(icon))
         self.result_found = True
         self.resultFetched.emit(result)
     
     @staticmethod
-    def getMatchingQgisIcon(file_type):
+    def get_matching_result_icon(file_type):
         parts = file_type.replace('.', ' ').replace('+', ' ').split()
+        
+        if 'zip' in parts:
+            return FILE_TYPE_ICONS.get('zip')
         
         for part in parts:
             if FILE_TYPE_ICONS.get(part):
@@ -175,14 +226,75 @@ class SwissLocatorFilterSTAC(SwissLocatorFilter):
         
         return FILE_TYPE_ICONS.get('default')
     
-    def fetch_asset(self, asset: STACResult):
-        # Try to get more info
-        url = asset.href
-        url = url_with_param(url, {})
-        request = QNetworkRequest(QUrl(url))
-        # TODO: Download file with QgsFileDownloader, using self.event_loop
-        self.fetch_request(request, QgsFeedback(), self.parse_asset_response)
+    def download_asset(self, asset: STACResult):
+        folder_path = get_save_location(self.tr("Choose download location"))
+        if not folder_path:
+            return
+        
+        file_path = os.path.join(folder_path, asset.asset_id)
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        
+        # Download the asset in a separate event loop
+        asset.path = file_path
+        url = url_with_param(asset.href, {})
+        self.info(f"fetching {url}")
+        
+        event_loop = QEventLoop()
+        
+        def on_download_error():
+            event_loop.quit()
+            level = Qgis.MessageLevel.Warning
+            msg = f"{self.tr('Unable to download file')}: {asset.asset_id}"
+            self.message_emitted.emit(self.displayName(), msg, level)
+            self.info(msg, level)
+        
+        fetcher = QgsFileDownloader(url, asset.href)
+        fetcher.downloadError.connect(on_download_error)
+        fetcher.downloadCanceled.connect(event_loop.quit)
+        fetcher.downloadCompleted.connect(
+                lambda: self.add_asset_to_qgis(asset))
+        fetcher.downloadCompleted.connect(event_loop.quit)
+        event_loop.exec(QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
     
-    def parse_asset_response(self):
-        # TODO: Download file
-        pass
+    def add_asset_to_qgis(self, asset: STACResult):
+        msg = ''
+        level = Qgis.MessageLevel.Info
+        
+        if not os.path.exists(asset.path) and not asset.is_streamed:
+            return
+        
+        if 'zip' in asset.path:
+            msg = f"{self.tr('File download finished')}: {asset.asset_id}"
+            self.message_emitted.emit(self.displayName(), msg, level)
+            self.info(msg, level)
+            return
+        
+        layer = None
+        try:
+            vectorLyr = QgsVectorLayer(asset.path, asset.asset_id, "ogr")
+            if vectorLyr.isValid():
+                layer = vectorLyr
+            else:
+                del vectorLyr
+        except Exception as e:
+            msg = e
+        
+        if not layer:
+            try:
+                rasterLyr = QgsRasterLayer(asset.path, asset.asset_id)
+                if rasterLyr.isValid():
+                    layer = rasterLyr
+                else:
+                    del rasterLyr
+            except Exception as e:
+                msg = e
+        
+        if layer:
+            QgsProject.instance().addMapLayer(layer)
+        else:
+            msg = f"{self.tr('Unable to add downloaded file to QGIS')} ({asset.asset_id}): {msg}"
+            level = Qgis.MessageLevel.Warning
+            self.info(msg, level)
+        
+        self.message_emitted.emit(self.displayName(), msg, level)

--- a/swiss_locator/core/results.py
+++ b/swiss_locator/core/results.py
@@ -25,6 +25,7 @@
 # ---------------------------------------------------------------------
 
 import json
+
 from qgis.core import QgsGeometry, QgsRectangle
 
 
@@ -158,6 +159,56 @@ class VectorTilesLayerResult:
             "style": self.style,
         }
         return json.dumps(definition)
+
+
+class STACResult:
+    
+    def __init__(self, collection_id: str, collection_name: str, asset_id: str,
+                 description: str, media_type: str, href: str):
+        self.collection_id = collection_id
+        self.collection_name = collection_name
+        self.asset_id = asset_id
+        self.description = description
+        self.media_type = media_type
+        self.href = href
+        self.simple_file_type = self._simple_file_type()
+    
+    def as_definition(self):
+        definition = {
+            "type": "STACResult",
+            "collection_id": self.collection_id,
+            "collection_name": self.collection_name,
+            "asset_id": self.asset_id,
+            "description": self.description,
+            "mediaType": self.media_type,
+            "href": self.href,
+        }
+        return json.dumps(definition)
+    
+    @staticmethod
+    def from_dict(dict_data: dict):
+        return STACResult(
+                dict_data["collection_id"],
+                dict_data["collection_name"],
+                dict_data["asset_id"],
+                dict_data["description"],
+                dict_data["mediaType"],
+                dict_data["href"],
+        )
+    
+    @property
+    def is_downloadable_file(self):
+        return self.asset_id and self.href
+    
+    def _simple_file_type(self):
+        try:
+            main_type = self.media_type.split(';')[0]
+        except IndexError:
+            return self.media_type
+        try:
+            return main_type.split('/')[-1]
+        except IndexError:
+            return main_type
 
 
 class NoResult:

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -33,6 +33,7 @@ from qgis.core import (
     QgsSettingsEntryInteger,
     QgsSettingsEntryStringList,
 )
+
 from swiss_locator.core.filters.filter_type import FilterType
 
 PLUGIN_NAME = "swiss_locator_plugin"
@@ -110,6 +111,17 @@ class Settings:
                     ),
                     "limit": QgsSettingsEntryInteger(
                         f"{FilterType.Layers.value}_limit", settings_node, 5
+                    ),
+                },
+                FilterType.STAC.value: {
+                    "priority": QgsSettingsEntryEnumFlag(
+                            f"{FilterType.STAC.value}_priority",
+                            settings_node,
+                            # TODO: What is appropriate?
+                            QgsLocatorFilter.Priority.High,
+                    ),
+                    "limit": QgsSettingsEntryInteger(
+                            f"{FilterType.STAC.value}_limit", settings_node, 5
                     ),
                 },
             }

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -123,6 +123,10 @@ class Settings:
                     "limit": QgsSettingsEntryInteger(
                             f"{FilterType.STAC.value}_limit", settings_node, 5
                     ),
+                    "max_files_per_result": QgsSettingsEntryInteger(
+                            f"{FilterType.STAC.value}_max_files_per_result",
+                            settings_node, 4
+                    ),
                 },
             }
             cls.filters = filters

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -117,15 +117,14 @@ class Settings:
                     "priority": QgsSettingsEntryEnumFlag(
                             f"{FilterType.STAC.value}_priority",
                             settings_node,
-                            # TODO: What is appropriate?
                             QgsLocatorFilter.Priority.High,
                     ),
                     "limit": QgsSettingsEntryInteger(
                             f"{FilterType.STAC.value}_limit", settings_node, 5
                     ),
-                    "max_files_per_result": QgsSettingsEntryInteger(
-                            f"{FilterType.STAC.value}_max_files_per_result",
-                            settings_node, 4
+                    "limit_files_per_result": QgsSettingsEntryInteger(
+                            f"{FilterType.STAC.value}limit_files_per_result",
+                            settings_node, 5
                     ),
                 },
             }

--- a/swiss_locator/core/settings.py
+++ b/swiss_locator/core/settings.py
@@ -123,7 +123,7 @@ class Settings:
                             f"{FilterType.STAC.value}_limit", settings_node, 5
                     ),
                     "limit_files_per_result": QgsSettingsEntryInteger(
-                            f"{FilterType.STAC.value}limit_files_per_result",
+                            f"{FilterType.STAC.value}_limit_files_per_result",
                             settings_node, 5
                     ),
                 },

--- a/swiss_locator/core/stac/stac_client.py
+++ b/swiss_locator/core/stac/stac_client.py
@@ -1,0 +1,58 @@
+from qgis.PyQt.QtCore import QUrl, QUrlQuery
+from qgis.core import (
+    QgsStacCollection,
+    QgsStacCollectionList,
+    QgsStacController,
+)
+
+
+class StacClient:
+    
+    def __init__(self, url):
+        self.url = url
+        self.controller = QgsStacController()
+        self.assetProperties = {}
+    
+    def fetchCollections(self, params: dict = None
+                         ) -> list[QgsStacCollection]:
+        """Get a list of all available collections and read out title,
+        description and other properties."""
+        
+        url = self._createUrl(f"{self.url}/collections", params)
+        errorMsg = ""
+        collections = []
+        
+        while url:
+            response: QgsStacCollectionList = self.controller.fetchCollections(
+                    url, errorMsg)
+            
+            if errorMsg or not response:
+                raise Exception(errorMsg)
+            
+            collections += response.takeCollections()
+            url = None
+            if (
+                    not params
+                    or not params.get("limit")
+                    or len(collections) < params["limit"]
+            ):
+                url = response.nextUrl() if not response.nextUrl().isEmpty() else None
+        
+        return collections
+    
+    @staticmethod
+    def _createUrl(baseUrl: str, urlParams: dict):
+        url = QUrl(baseUrl)
+        if urlParams:
+            queryParams = QUrlQuery()
+            for key, value in urlParams.items():
+                if value is None or value == "" or value == []:
+                    continue
+                if isinstance(value, list):
+                    param = ",".join([str(v) for v in value])
+                else:
+                    param = str(value)
+                queryParams.addQueryItem(key, param)
+            url.setQuery(queryParams)
+        
+        return url

--- a/swiss_locator/core/stac/stac_client.py
+++ b/swiss_locator/core/stac/stac_client.py
@@ -6,7 +6,7 @@ from qgis.core import (
 )
 
 
-class StacClient:
+class STACClient:
     
     def __init__(self, url):
         self.url = url

--- a/swiss_locator/core/stac/stac_client.py
+++ b/swiss_locator/core/stac/stac_client.py
@@ -15,8 +15,7 @@ class StacClient:
     
     def fetchCollections(self, params: dict = None
                          ) -> list[QgsStacCollection]:
-        """Get a list of all available collections and read out title,
-        description and other properties."""
+        """Get a list of all available collections."""
         
         url = self._createUrl(f"{self.url}/collections", params)
         errorMsg = ""

--- a/swiss_locator/gui/config_dialog.py
+++ b/swiss_locator/gui/config_dialog.py
@@ -22,8 +22,15 @@
 """
 
 import os
+
 from qgis.PyQt.QtCore import Qt, pyqtSlot
-from qgis.PyQt.QtWidgets import QDialog, QTableWidgetItem, QAbstractItemView, QComboBox
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QTableWidgetItem,
+    QAbstractItemView,
+    QComboBox,
+    QSpinBox
+)
 from qgis.PyQt.uic import loadUiType
 from qgis.core import QgsLocatorFilter
 from qgis.gui import (
@@ -31,14 +38,15 @@ from qgis.gui import (
     QgsSettingsBoolCheckBoxWrapper,
     QgsSettingsEnumEditorWidgetWrapper,
     QgsSettingsEditorWidgetWrapper,
+    QgsSettingsIntegerSpinBoxWrapper,
 )
 
-from ..core.settings import Settings
-from ..core.language import get_language
-from ..map_geo_admin.layers import searchable_layers
 from .qtwebkit_conf import with_qt_web_kit
 from ..core.filters.filter_type import FilterType
+from ..core.language import get_language
 from ..core.parameters import AVAILABLE_LANGUAGES
+from ..core.settings import Settings
+from ..map_geo_admin.layers import searchable_layers
 
 DialogUi, _ = loadUiType(os.path.join(os.path.dirname(__file__), "../ui/config.ui"))
 
@@ -105,6 +113,19 @@ class ConfigDialog(QDialog, DialogUi):
                     displayStrings=display_strings,
                 )
                 self.wrappers.append(ew)
+            
+            sb = self.findChild(QSpinBox, "{}_limit".format(filter_type.value))
+            if sb is not None:
+                sbw = QgsSettingsIntegerSpinBoxWrapper(
+                        sb, self.settings.filters[filter_type.value]["limit"])
+                self.wrappers.append(sbw)
+        
+        sb_stac = self.findChild(QSpinBox, "stac_limit_files_per_result")
+        if sb_stac is not None:
+            sbw_stac = QgsSettingsIntegerSpinBoxWrapper(
+                    sb_stac, self.settings.filters[filter_type.value][
+                        "limit_files_per_result"])
+            self.wrappers.append(sbw_stac)
 
         self.search_line_edit.textChanged.connect(self.filter_rows)
         self.select_all_button.pressed.connect(self.select_all)

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -84,7 +84,7 @@ class SwissLocatorPlugin:
             SwissLocatorFilterLayer,
             SwissLocatorFilterVectorTiles,
             SwissLocatorFilterFeature,
-                SwissLocatorFilterSTAC
+            SwissLocatorFilterSTAC
         ):
             self.locator_filters.append(_filter(self.iface))
             self.iface.registerLocatorFilter(self.locator_filters[-1])

--- a/swiss_locator/swiss_locator_plugin.py
+++ b/swiss_locator/swiss_locator_plugin.py
@@ -18,9 +18,16 @@
 """
 
 import os
+
 from qgis.PyQt.QtCore import QCoreApplication, QLocale, QSettings, QTranslator
 from qgis.PyQt.QtWidgets import QWidget
-from qgis.core import Qgis, QgsApplication, QgsMessageLog, NULL, QgsSettingsTree
+from qgis.core import (
+    Qgis,
+    QgsApplication,
+    QgsMessageLog,
+    NULL,
+    QgsSettingsTree
+)
 from qgis.gui import QgisInterface, QgsMessageBarItem
 
 from swiss_locator.core.filters.swiss_locator_filter_feature import (
@@ -32,9 +39,14 @@ from swiss_locator.core.filters.swiss_locator_filter_layer import (
 from swiss_locator.core.filters.swiss_locator_filter_location import (
     SwissLocatorFilterLocation,
 )
-from swiss_locator.core.filters.swiss_locator_filter_wmts import SwissLocatorFilterWMTS
+from swiss_locator.core.filters.swiss_locator_filter_stac import (
+    SwissLocatorFilterSTAC
+)
 from swiss_locator.core.filters.swiss_locator_filter_vector_tiles import (
     SwissLocatorFilterVectorTiles,
+)
+from swiss_locator.core.filters.swiss_locator_filter_wmts import (
+    SwissLocatorFilterWMTS
 )
 
 try:
@@ -72,6 +84,7 @@ class SwissLocatorPlugin:
             SwissLocatorFilterLayer,
             SwissLocatorFilterVectorTiles,
             SwissLocatorFilterFeature,
+                SwissLocatorFilterSTAC
         ):
             self.locator_filters.append(_filter(self.iface))
             self.iface.registerLocatorFilter(self.locator_filters[-1])

--- a/swiss_locator/tests/test_locator_filter.py
+++ b/swiss_locator/tests/test_locator_filter.py
@@ -15,13 +15,17 @@
 """
 
 from qgis.PyQt.QtTest import QSignalSpy
-
+from qgis._core import QgsStacExtent
+from qgis.core import QgsStacCollection, QgsLocator, QgsLocatorContext
 from qgis.testing import start_app, unittest
 from qgis.testing.mocked import get_iface
 
-from qgis.core import QgsLocator, QgsLocatorContext
-
-from swiss_locator.core.filters.swiss_locator_filter_wmts import SwissLocatorFilterWMTS
+from swiss_locator.core.filters.map_geo_admin_stac import \
+    collections_to_searchable_strings
+from swiss_locator.core.filters.swiss_locator_filter_stac import \
+    SwissLocatorFilterSTAC
+from swiss_locator.core.filters.swiss_locator_filter_wmts import \
+    SwissLocatorFilterWMTS
 
 start_app()
 
@@ -57,3 +61,51 @@ class TestSwissLocatorFilters(unittest.TestCase):
         spy.wait(1000)
 
         self.assertTrue(got_hit._results_[0].startswith("National Map"))
+
+
+class TestLocatorFilterSTAC(unittest.TestCase):
+    
+    @classmethod
+    def setUpClass(cls):
+        cls.test_strings = (
+            ('ch.swisstopo.swissalti3d', 'swissALTI3D'),
+            ('ch.bakom.mobilnetz-2g', '2G - GSM / EDGE Verfügbarkeit'),
+            ('ch.bafu.wald-wasserverfuegbarkeit_boden',
+                'Wasserverfügbarkeit im Boden (Standortwasserbilanz)'),
+        )
+        cls.collections = {}
+        for key, title in cls.test_strings:
+            cls.collections[key] = QgsStacCollection(key, None, None, [], None,
+                                                     QgsStacExtent())
+            cls.collections[key].setTitle(title)
+    
+    def setUp(self):
+        pass
+    
+    def test_collections_to_searchable_strings(self):
+        search_strings, search_ids = collections_to_searchable_strings(
+                self.collections)
+        
+        self.assertEqual(search_strings, [
+            'swissalti3d ch.swisstopo.swissalti3d',
+            '2g - gsm / edge verfügbarkeit ch.bakom.mobilnetz-2g',
+            'wasserverfügbarkeit im boden (standortwasserbilanz) ch.bafu.wald-wasserverfuegbarkeit_boden'
+        ])
+    
+    def test_local_search(self):
+        search_strings, search_ids = collections_to_searchable_strings(
+                self.collections)
+        
+        loc = QgsLocator()
+        _filter = SwissLocatorFilterSTAC(get_iface(), None,
+                                         [self.collections, search_strings,
+                                             search_ids])
+        loc.registerFilter(_filter)
+        
+        search_res_1 = _filter.perform_local_search('gsm')
+        search_res_2 = _filter.perform_local_search('verfügbarkeit')
+        
+        self.assertEqual(search_res_1, ['ch.bakom.mobilnetz-2g'])
+        self.assertEqual(search_res_2,
+                         ['ch.bafu.wald-wasserverfuegbarkeit_boden',
+                             'ch.bakom.mobilnetz-2g'])

--- a/swiss_locator/ui/config.ui
+++ b/swiss_locator/ui/config.ui
@@ -27,7 +27,7 @@
    <item row="3" column="0" colspan="3">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="locations">
       <attribute name="title">
@@ -303,6 +303,73 @@
           </item>
          </layout>
         </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="stac">
+      <attribute name="title">
+       <string>STAC file download</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_8">
+       <item row="0" column="0">
+        <layout class="QGridLayout" name="gridLayout_7">
+         <item row="0" column="1">
+          <widget class="QComboBox" name="stac_priority"/>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_19">
+           <property name="text">
+            <string>Filter priority</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <spacer name="verticalSpacer_7">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_20">
+           <property name="text">
+            <string>Maximum number of results</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="stac_limit"/>
+         </item>
+         <item row="0" column="2">
+          <spacer name="horizontalSpacer_12">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_21">
+           <property name="text">
+            <string>Maximum number of files per result</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="stac_limit_files_per_result"/>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/swiss_locator/utils/utils.py
+++ b/swiss_locator/utils/utils.py
@@ -1,10 +1,22 @@
+import os
+
 from qgis.PyQt.QtCore import QUrl, QUrlQuery
+from qgis.PyQt.QtWidgets import QFileDialog
 
 
-def url_with_param(url: str, params: dict) -> str:
+def url_with_param(url: str, params: dict) -> QUrl:
     url = QUrl(url)
     q = QUrlQuery(url)
     for key, value in params.items():
         q.addQueryItem(key, value)
     url.setQuery(q)
     return url
+
+
+def get_save_location(prompt: str = "Choose download location",
+                      open_dir: str = None):
+    if not open_dir:
+        open_dir = os.path.expanduser('~')
+    path = QFileDialog.getExistingDirectory(None, prompt, open_dir,
+                                            QFileDialog.Option.ShowDirsOnly)
+    return path


### PR DESCRIPTION
This PR is part 1 of 2 of adding the Swisstopo STAC catalog to the swiss locator.

This PR contains a new locator filter class for swisstopo STAC results called `SwissLocatorFilterSTAC`:
- it fetches all collections from the catalog and request metadata (title, description) in the correct language
- when searching, it goes through all collection ids and titles to find matching collections
- for each matching collection, it requests items and their assets (=downloadable files)
- it displays a list of downloadable files per collection, or...
- in the case of collections with many items, it links to a filter dialog, where items and their assets can be queried (dialog to be added in part 2)
- it downloads files to the filesystem
- if possible, a layer object is created and added to QGIS  (.zip files aren't added)
- in the case of cloud optimized geotiffs, the user can choose to download the file or stream it

A few things to note:
- The STAC catalog does not provide a search endpoint to search collection titles, therefore the collections have to be initially requested and the search has to be done locally
- The STAC catalog isn't multi-lingual, titles in the correct language are requested from another Swisstopo endpoint
- To keep the locator filter simple and consistent with existing filters, the STAC items are requested through existing methods of the `SwissLocatorFilter` base class, and not via the new QgsStac python bindings