### PR TITLE
Add stac filter - addendum

### DIFF
--- a/swiss_locator/__init__.py
+++ b/swiss_locator/__init__.py
@@ -21,7 +21,10 @@
  ***************************************************************************/
 """
 
+import os
+
 DEBUG = False
+PLUGIN_PATH = os.path.dirname(__file__)
 
 
 def classFactory(iface):

--- a/swiss_locator/core/filters/swiss_locator_filter_feature.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_feature.py
@@ -18,6 +18,7 @@
 """
 
 import json
+import os
 
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import (
@@ -28,6 +29,7 @@ from qgis.core import (
 )
 from qgis.gui import QgisInterface
 
+from swiss_locator import PLUGIN_PATH
 from swiss_locator.core.filters.filter_type import FilterType
 from swiss_locator.core.filters.map_geo_admin import map_geo_admin_url
 from swiss_locator.core.filters.swiss_locator_filter import (
@@ -105,6 +107,7 @@ class SwissLocatorFilterFeature(SwissLocatorFilter):
                 layer=layer,
                 feature_id=loc["attrs"]["feature_id"],
             ).as_definition()
-            result.icon = QIcon(":/plugins/swiss_locator/icons/swiss_locator.png")
+            result.icon = QIcon(
+                str(os.path.join(PLUGIN_PATH, "icons", "swiss_locator.png")))
             self.result_found = True
             self.resultFetched.emit(result)

--- a/swiss_locator/core/filters/swiss_locator_filter_location.py
+++ b/swiss_locator/core/filters/swiss_locator_filter_location.py
@@ -17,15 +17,14 @@
  ***************************************************************************/
 """
 
-import traceback
 import json
-import sys
 import os
+import sys
+import traceback
 
 from qgis.PyQt.QtCore import QUrl
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtNetwork import QNetworkRequest
-
 from qgis.core import (
     Qgis,
     QgsLocatorResult,
@@ -36,9 +35,10 @@ from qgis.core import (
 )
 from qgis.gui import QgisInterface
 
-from swiss_locator.core.filters.swiss_locator_filter import SwissLocatorFilter
+from swiss_locator import PLUGIN_PATH
 from swiss_locator.core.filters.filter_type import FilterType
 from swiss_locator.core.filters.map_geo_admin import map_geo_admin_url
+from swiss_locator.core.filters.swiss_locator_filter import SwissLocatorFilter
 from swiss_locator.core.results import LocationResult
 from swiss_locator.utils.html_stripper import strip_tags
 from swiss_locator.utils.utils import url_with_param
@@ -94,7 +94,8 @@ class SwissLocatorFilterLocation(SwissLocatorFilter):
                     else None,
                     html_label=loc["attrs"]["label"],
                 ).as_definition()
-                result.icon = QIcon(":/plugins/swiss_locator/icons/swiss_locator.png")
+                result.icon = QIcon(str(os.path.join(PLUGIN_PATH, "icons",
+                                                     "swiss_locator.png")))
                 self.result_found = True
                 self.resultFetched.emit(result)
 

--- a/swiss_locator/metadata.txt
+++ b/swiss_locator/metadata.txt
@@ -1,7 +1,7 @@
 
 [general]
 name=Swiss Locator
-qgisMinimumVersion=3.39
+qgisMinimumVersion=3.44
 description=A locator filter for Swiss Geoportal (geo.admin.ch) and opendata.swiss resources
 about=Search for locations, WMS layers of features in the whole Swiss Geoportal catalog as well as in opendata.swiss
 version=dev

--- a/swiss_locator/resources.qrc
+++ b/swiss_locator/resources.qrc
@@ -1,5 +1,0 @@
-<RCC>
-    <qresource prefix="/plugins/swiss_locator">
-        <file>icons/swiss_locator.png</file>
-    </qresource>
-</RCC>

--- a/swiss_locator/swissgeodownloader/api/network_request.py
+++ b/swiss_locator/swissgeodownloader/api/network_request.py
@@ -52,7 +52,7 @@ def fetch(
     if header:
         request.setHeader(*tuple(header))
     
-    log(translate("SGD", "Start request {}").format(callUrl))
+    log(translate("SGD", "Start request {}").format(callUrl.toString()))
     # Start request
     http = QgsBlockingNetworkRequest()
     if method == "get":
@@ -68,7 +68,7 @@ def fetch(
         # Service is not reachable
         task.exception = translate("SGD",
                                    "{} not reachable or no internet connection").format(
-                callUrl)
+                callUrl.toString())
         # Service returned an error
         if r.content():
             try:
@@ -78,7 +78,8 @@ def fetch(
                 raise e
             if "code" and "description" in errorResp:
                 task.exception = (
-                        translate("SGD", "{} returns error").format(callUrl)
+                        translate("SGD", "{} returns error").format(
+                            callUrl.toString())
                         + f": {errorResp['code']} - {errorResp['description']}"
                 )
         return False


### PR DESCRIPTION
Addendum to the STAC PR:

- `metadata.txt` contained the wrong minimum QGIS version, new STAC functionalities were introduced in QGIS 3.44!

While fixing this, I also realized two additional problems:
-  missing icon for location and feature results. The `resources.qrc` is still in the repo, but not imported anymore. I deleted it. Instead, icons are now loaded via their absolute path.
-  Request logging showed URL objects instead of URL strings

